### PR TITLE
Remove regex dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,3 @@ authors = ["Thijs Cadier <thijs@appsignal.com>",
            "Robert Beekman <robert@appsignal.com>",
            "Dax Huiberts <daxhuiberts@gmail.com>",
            "Timon Vonk <mail@timonv.nl>"]
-
-[dependencies]
-regex        = "*"
-regex_macros = "*"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,6 +11,6 @@ Vagrant.configure(2) do |config|
     curl -o blastoff.sh https://raw.githubusercontent.com/brson/multirust/master/blastoff.sh
     sh blastoff.sh --yes
     rm -f blastoff.sh
-    multirust default nightly
+    multirust default stable
   SHELL
 end

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,3 @@
-#![feature(plugin)]
-#![plugin(regex_macros)]
-extern crate regex;
-
 mod error;
 pub mod load;
 pub mod memory;


### PR DESCRIPTION
We're not using it at the moment. Without this dependence we can run on stable Rust.
