### PR TITLE
Cache cargo's registry locally to speed it up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target
 Cargo.lock
 .vagrant
+/tmp

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,19 @@ build:
 	docker build -t probes/ubuntu_1604 docker/ubuntu_1604
 
 test:
-	docker run --rm -v $(PWD):/probes -t probes/centos_7 /bin/bash -c "source /root/.cargo/env; cd /probes; rm -f Cargo.lock; cargo test"
-	docker run --rm -v $(PWD):/probes -t probes/ubuntu_1204 /bin/bash -c "source /root/.cargo/env; cd /probes; rm -f Cargo.lock; cargo test"
-	docker run --rm -v $(PWD):/probes -t probes/ubuntu_1404 /bin/bash -c "source /root/.cargo/env; cd /probes; rm -f Cargo.lock; cargo test"
-	docker run --rm -v $(PWD):/probes -t probes/ubuntu_1604 /bin/bash -c "source /root/.cargo/env; cd /probes; rm -f Cargo.lock; cargo test"
+	docker run --rm \
+		-v $(PWD)/tmp/centos_7/.cargo/registry:/root/.cargo/registry \
+		-v $(PWD):/probes -t probes/centos_7 \
+		/bin/bash -c "source /root/.cargo/env; cd /probes; rm -f Cargo.lock; cargo test"
+	docker run --rm \
+		-v $(PWD)/tmp/ubuntu_1204/.cargo/registry:/root/.cargo/registry \
+		-v $(PWD):/probes -t probes/ubuntu_1404 \
+		/bin/bash -c "source /root/.cargo/env; cd /probes; rm -f Cargo.lock; cargo test"
+	docker run --rm \
+		-v $(PWD)/tmp/ubuntu_1404/.cargo/registry:/root/.cargo/registry \
+		-v $(PWD):/probes -t probes/ubuntu_1404 \
+		/bin/bash -c "source /root/.cargo/env; cd /probes; rm -f Cargo.lock; cargo test"
+	docker run --rm \
+		-v $(PWD)/tmp/ubuntu_1604/.cargo/registry:/root/.cargo/registry \
+		-v $(PWD):/probes -t probes/ubuntu_1604 \
+		/bin/bash -c "source /root/.cargo/env; cd /probes; rm -f Cargo.lock; cargo test"


### PR DESCRIPTION
Caches the build dependency locally per docker image.
Speeds up the tests considerably, also easier on the rust registry.

This caches the dependencies of the build, so if you have problems with dependencies being out of date or you want to upgrade them, remove the cached directory in the `tmp/` dir and re-run the tests.