### PR TITLE
Fix time_adjusted calculations

### DIFF
--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -478,17 +478,17 @@ mod test {
         };
 
         let expected = CpuStat {
-            total: 30,
-            user: 3,
-            nice: 3,
-            system: 3,
-            idle: 3,
-            iowait: 3,
-            irq: 3,
-            softirq: 3,
-            steal: 3,
-            guest: 3,
-            guestnice: 3
+            total: 120,
+            user: 12,
+            nice: 12,
+            system: 12,
+            idle: 12,
+            iowait: 12,
+            irq: 12,
+            softirq: 12,
+            steal: 12,
+            guest: 12,
+            guestnice: 12
         };
 
         let stat = measurement1.calculate_per_minute(&measurement2).unwrap();

--- a/src/disk_stats.rs
+++ b/src/disk_stats.rs
@@ -285,17 +285,17 @@ mod tests {
 
         let per_minute = measurement1.calculate_per_minute(&measurement2).unwrap();
         let sda1 = per_minute.stats.get("sda1").unwrap();
-        assert_eq!(sda1.reads_completed_successfully, 60);
-        assert_eq!(sda1.reads_merged, 60);
-        assert_eq!(sda1.sectors_read, 60);
-        assert_eq!(sda1.time_spent_reading_ms, 60);
-        assert_eq!(sda1.writes_completed, 60);
-        assert_eq!(sda1.writes_merged, 60);
-        assert_eq!(sda1.sectors_written, 60);
-        assert_eq!(sda1.time_spent_writing_ms, 60);
-        assert_eq!(sda1.ios_currently_in_progress, 60);
-        assert_eq!(sda1.time_spent_doing_ios_ms, 60);
-        assert_eq!(sda1.weighted_time_spent_doing_ios_ms, 60);
+        assert_eq!(sda1.reads_completed_successfully, 240);
+        assert_eq!(sda1.reads_merged, 240);
+        assert_eq!(sda1.sectors_read, 240);
+        assert_eq!(sda1.time_spent_reading_ms, 240);
+        assert_eq!(sda1.writes_completed, 240);
+        assert_eq!(sda1.writes_merged, 240);
+        assert_eq!(sda1.sectors_written, 240);
+        assert_eq!(sda1.time_spent_writing_ms, 240);
+        assert_eq!(sda1.ios_currently_in_progress, 240);
+        assert_eq!(sda1.time_spent_doing_ios_ms, 240);
+        assert_eq!(sda1.weighted_time_spent_doing_ios_ms, 240);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,7 @@ fn time_adjusted(field_name: &str, first_value: u64, second_value: u64, time_dif
     if first_value < second_value {
         Err(ProbeError::UnexpectedContent(format!("First value {} was lower than second value {} for '{}'", first_value, second_value, field_name)))
     } else {
-        Ok((first_value - second_value) * time_difference_ns / 60_000_000_000)
+        Ok(((first_value - second_value) as f64 / time_difference_ns as f64 * 60_000_000_000.0) as u64)
     }
 }
 
@@ -95,8 +95,8 @@ mod tests {
     #[test]
     fn test_time_adjusted() {
         assert_eq!(1200, super::time_adjusted("field", 2400, 1200, 60_000_000_000).unwrap());
-        assert_eq!(600, super::time_adjusted("field", 2400, 1200, 30_000_000_000).unwrap());
-        assert_eq!(300, super::time_adjusted("field", 2400, 1200, 15_000_000_000).unwrap());
+        assert_eq!(2400, super::time_adjusted("field", 2400, 1200, 30_000_000_000).unwrap());
+        assert_eq!(4800, super::time_adjusted("field", 2400, 1200, 15_000_000_000).unwrap());
     }
 
     #[test]

--- a/src/network.rs
+++ b/src/network.rs
@@ -287,12 +287,12 @@ mod tests {
         assert_eq!(2, per_minute.interfaces.len());
 
         let eth0 = per_minute.interfaces.get("eth0").unwrap();
-        assert_eq!(500, eth0.received);
-        assert_eq!(800, eth0.transmitted);
+        assert_eq!(2000, eth0.received);
+        assert_eq!(3200, eth0.transmitted);
 
         let eth1 = per_minute.interfaces.get("eth0").unwrap();
-        assert_eq!(500, eth1.received);
-        assert_eq!(800, eth1.transmitted);
+        assert_eq!(2000, eth1.received);
+        assert_eq!(3200, eth1.transmitted);
     }
 
     #[test]


### PR DESCRIPTION
## Some context about the `time_adjusted` function

The `time_adjusted` function returns a value calculated for a minute. It
received two values, for which it calculates the delta first. Then,
using the `time_difference_ns` value (the time in which these values
were measured), it calculates the value as it would be for a full
minute.

When the `time_difference_ns` is 59 seconds or 61 seconds it returns the
value as it would be for 60 seconds instead. This helps account for
small drift within the time at which the metrics were measured.

## The problem

The previous implementation of the time_adjusted function would multiple
the delta value by the real time (30 seconds) and divide that value by
60 seconds.

The problem here was that it would not return the value for 60 seconds,
but instead that for 15 seconds, half of 30 seconds.

```
delta = 10.0
time_difference = 30.0
expected_time = 60.0

delta * real_time / expected_time
=> 5.0
```

5.0 being half of 10.0 (the delta), half of 30 seconds.

## The fix

Instead of multiplying the delta by `time_difference_ns` we should
divide the delta by the `time_difference_ns` to get the value per
nanosecond (ns). Then we multiply that 1 nanosecond value by 60 seconds.
This will return the average value for 60 seconds.

```
delta = 10.0
time_difference = 30.0
expected_time = 60.0

delta / real_time * expected_time
=> 20.0
```

20.0 being double of 10.0 (the delta), double of 30 seconds.