### PR TITLE
Fix "time" version dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,5 @@ keywords = ["unix", "linux", "probe"]
 license = "MIT"
 
 [dependencies]
-libc = ">= 0.2.0"
-time = ">= 0.1.34"
+libc = "0.2"
+time = "0.1.34"


### PR DESCRIPTION
Now that time 0.2 is released this build is broken due to an incompatible change between time 0.1 and 0.2. Fix dependency declaration in Cargo.toml to obey SemVer semantics.