### PR TITLE
Source cleanup: compiler warnings and formatting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "probes"
-version = "0.2.2"
+version = "0.2.3-dev"
 authors = ["Thijs Cadier <thijs@appsignal.com>",
            "Robert Beekman <robert@appsignal.com>",
            "Timon Vonk <mail@timonv.nl>"]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Crate](http://meritbadge.herokuapp.com/probes)](https://crates.io/crates/probes)
 
 Rust library to read out system stats from a machine running Unix.
-Currently only supports Linux.
+Currently only supports Linux. Minimum supported Rust version is 1.36.0.
 
 ## Supported stats
 

--- a/src/cpu/cgroup.rs
+++ b/src/cpu/cgroup.rs
@@ -1,30 +1,49 @@
-use super::super::{Result,calculate_time_difference,time_adjusted};
+use super::super::{calculate_time_difference, time_adjusted, Result};
 
 /// Measurement of cpu stats at a certain time
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct CgroupCpuMeasurement {
     pub precise_time_ns: u64,
-    pub stat: CgroupCpuStat
+    pub stat: CgroupCpuStat,
 }
 
 impl CgroupCpuMeasurement {
-    pub fn calculate_per_minute(&self, next_measurement: &CgroupCpuMeasurement) -> Result<CgroupCpuStat> {
-        let time_difference = calculate_time_difference(self.precise_time_ns, next_measurement.precise_time_ns)?;
+    pub fn calculate_per_minute(
+        &self,
+        next_measurement: &CgroupCpuMeasurement,
+    ) -> Result<CgroupCpuStat> {
+        let time_difference =
+            calculate_time_difference(self.precise_time_ns, next_measurement.precise_time_ns)?;
 
         Ok(CgroupCpuStat {
-            total_usage: time_adjusted("total_usage", next_measurement.stat.total_usage, self.stat.total_usage, time_difference)?,
-            user: time_adjusted("user", next_measurement.stat.user, self.stat.user, time_difference)?,
-            system: time_adjusted("system", next_measurement.stat.system, self.stat.system, time_difference)?
+            total_usage: time_adjusted(
+                "total_usage",
+                next_measurement.stat.total_usage,
+                self.stat.total_usage,
+                time_difference,
+            )?,
+            user: time_adjusted(
+                "user",
+                next_measurement.stat.user,
+                self.stat.user,
+                time_difference,
+            )?,
+            system: time_adjusted(
+                "system",
+                next_measurement.stat.system,
+                self.stat.system,
+                time_difference,
+            )?,
         })
     }
 }
 
 /// Container CPU stats for a minute
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct CgroupCpuStat {
     pub total_usage: u64,
     pub user: u64,
-    pub system: u64
+    pub system: u64,
 }
 
 impl CgroupCpuStat {
@@ -33,7 +52,7 @@ impl CgroupCpuStat {
         CgroupCpuStatPercentages {
             total_usage: self.percentage_of_total(self.total_usage),
             user: self.percentage_of_total(self.user),
-            system: self.percentage_of_total(self.system)
+            system: self.percentage_of_total(self.system),
         }
     }
 
@@ -44,11 +63,11 @@ impl CgroupCpuStat {
 }
 
 /// Cgroup Cpu stats converted to percentages
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct CgroupCpuStatPercentages {
     pub total_usage: f32,
     pub user: f32,
-    pub system: f32
+    pub system: f32,
 }
 
 /// Read the current CPU stats of the container.
@@ -59,12 +78,14 @@ pub fn read() -> Result<CgroupCpuMeasurement> {
 
 #[cfg(target_os = "linux")]
 mod os {
-    use std::path::Path;
-    use std::io::BufRead;
-    use time;
-    use super::super::super::{Result,file_to_buf_reader,parse_u64,path_to_string,read_file_value_as_u64,dir_exists};
-    use super::{CgroupCpuMeasurement,CgroupCpuStat};
+    use super::super::super::{
+        dir_exists, file_to_buf_reader, parse_u64, path_to_string, read_file_value_as_u64, Result,
+    };
+    use super::{CgroupCpuMeasurement, CgroupCpuStat};
     use error::ProbeError;
+    use std::io::BufRead;
+    use std::path::Path;
+    use time;
 
     const CPU_SYS_NUMBER_OF_FIELDS: usize = 2;
 
@@ -73,7 +94,10 @@ mod os {
         if dir_exists(sys_fs_dir) {
             read_and_parse_sys_stat(&sys_fs_dir)
         } else {
-            let message = format!("Directory `{}` not found", sys_fs_dir.to_str().unwrap_or("unknown path"));
+            let message = format!(
+                "Directory `{}` not found",
+                sys_fs_dir.to_str().unwrap_or("unknown path")
+            );
             Err(ProbeError::UnexpectedContent(message))
         }
     }
@@ -84,9 +108,9 @@ mod os {
         let total_usage = read_file_value_as_u64(&path.join("cpuacct.usage"))?;
 
         let mut cpu = CgroupCpuStat {
-            total_usage: total_usage,
+            total_usage,
             user: 0,
-            system: 0
+            system: 0,
         };
 
         let mut fields_encountered = 0;
@@ -98,25 +122,27 @@ mod os {
                 "user" => {
                     cpu.user = value * 10_000_000;
                     1
-                },
+                }
                 "system" => {
                     cpu.system = value * 10_000_000;
                     1
-                },
-                _ => 0
+                }
+                _ => 0,
             };
 
             if fields_encountered == CPU_SYS_NUMBER_OF_FIELDS {
-                break
+                break;
             }
         }
 
         if fields_encountered != CPU_SYS_NUMBER_OF_FIELDS {
-            return Err(ProbeError::UnexpectedContent("Did not encounter all expected fields".to_owned()))
+            return Err(ProbeError::UnexpectedContent(
+                "Did not encounter all expected fields".to_owned(),
+            ));
         }
         let measurement = CgroupCpuMeasurement {
             precise_time_ns: time,
-            stat: cpu
+            stat: cpu,
         };
         Ok(measurement)
     }
@@ -124,10 +150,10 @@ mod os {
 
 #[cfg(test)]
 mod test {
-    use super::{CgroupCpuMeasurement,CgroupCpuStat};
     use super::os::read_and_parse_sys_stat;
-    use std::path::Path;
+    use super::{CgroupCpuMeasurement, CgroupCpuStat};
     use error::ProbeError;
+    use std::path::Path;
 
     #[test]
     fn test_read() {
@@ -136,7 +162,8 @@ mod test {
 
     #[test]
     fn test_read_sys_measurement() {
-        let measurement = read_and_parse_sys_stat(&Path::new("fixtures/linux/sys/fs/cgroup/cpuacct_1/")).unwrap();
+        let measurement =
+            read_and_parse_sys_stat(&Path::new("fixtures/linux/sys/fs/cgroup/cpuacct_1/")).unwrap();
         let cpu = measurement.stat;
         assert_eq!(cpu.total_usage, 152657213021);
         assert_eq!(cpu.user, 149340000000);
@@ -147,15 +174,17 @@ mod test {
     fn test_read_sys_wrong_path() {
         match read_and_parse_sys_stat(&Path::new("bananas")) {
             Err(ProbeError::IO(_, _)) => (),
-            r => panic!("Unexpected result: {:?}", r)
+            r => panic!("Unexpected result: {:?}", r),
         }
     }
 
     #[test]
     fn test_read_and_parse_sys_stat_incomplete() {
-        match read_and_parse_sys_stat(&Path::new("fixtures/linux/sys/fs/cgroup/cpuacct_incomplete/")) {
+        match read_and_parse_sys_stat(&Path::new(
+            "fixtures/linux/sys/fs/cgroup/cpuacct_incomplete/",
+        )) {
             Err(ProbeError::UnexpectedContent(_)) => (),
-            r => panic!("Unexpected result: {:?}", r)
+            r => panic!("Unexpected result: {:?}", r),
         }
     }
 
@@ -164,7 +193,7 @@ mod test {
         let path = Path::new("fixtures/linux/sys/fs/cgroup/cpuacct_garbage/");
         match read_and_parse_sys_stat(&path) {
             Err(ProbeError::UnexpectedContent(_)) => (),
-            r => panic!("Unexpected result: {:?}", r)
+            r => panic!("Unexpected result: {:?}", r),
         }
     }
 
@@ -175,8 +204,8 @@ mod test {
             stat: CgroupCpuStat {
                 total_usage: 0,
                 user: 0,
-                system: 0
-            }
+                system: 0,
+            },
         };
 
         let measurement2 = CgroupCpuMeasurement {
@@ -184,16 +213,15 @@ mod test {
             stat: CgroupCpuStat {
                 total_usage: 0,
                 user: 0,
-                system: 0
-            }
+                system: 0,
+            },
         };
 
         match measurement1.calculate_per_minute(&measurement2) {
             Err(ProbeError::InvalidInput(_)) => (),
-            r => panic!("Unexpected result: {:?}", r)
+            r => panic!("Unexpected result: {:?}", r),
         }
     }
-
 
     #[test]
     fn test_cgroup_calculate_per_minute_full_minute() {
@@ -202,8 +230,8 @@ mod test {
             stat: CgroupCpuStat {
                 total_usage: 6380,
                 user: 1000,
-                system: 1200
-            }
+                system: 1200,
+            },
         };
 
         let measurement2 = CgroupCpuMeasurement {
@@ -211,14 +239,14 @@ mod test {
             stat: CgroupCpuStat {
                 total_usage: 6440,
                 user: 1006,
-                system: 1206
-            }
+                system: 1206,
+            },
         };
 
         let expected = CgroupCpuStat {
             total_usage: 60,
             user: 6,
-            system: 6
+            system: 6,
         };
 
         let stat = measurement1.calculate_per_minute(&measurement2).unwrap();
@@ -233,8 +261,8 @@ mod test {
             stat: CgroupCpuStat {
                 total_usage: 1_000_000_000,
                 user: 10000_000_000,
-                system: 12000_000_000
-            }
+                system: 12000_000_000,
+            },
         };
 
         let measurement2 = CgroupCpuMeasurement {
@@ -242,14 +270,14 @@ mod test {
             stat: CgroupCpuStat {
                 total_usage: 1_500_000_000,
                 user: 10060_000_000,
-                system: 12060_000_000
-            }
+                system: 12060_000_000,
+            },
         };
 
         let expected = CgroupCpuStat {
             total_usage: 1_000_000_000,
             user: 120_000_000,
-            system: 120_000_000
+            system: 120_000_000,
         };
 
         let stat = measurement1.calculate_per_minute(&measurement2).unwrap();
@@ -264,8 +292,8 @@ mod test {
             stat: CgroupCpuStat {
                 total_usage: 63800_000_000,
                 user: 10000_000_000,
-                system: 12000_000_000
-            }
+                system: 12000_000_000,
+            },
         };
 
         let measurement2 = CgroupCpuMeasurement {
@@ -273,13 +301,13 @@ mod test {
             stat: CgroupCpuStat {
                 total_usage: 10400_000_000,
                 user: 1060_000_000,
-                system: 1260_000_000
-            }
+                system: 1260_000_000,
+            },
         };
 
         match measurement1.calculate_per_minute(&measurement2) {
             Err(ProbeError::UnexpectedContent(_)) => (),
-            r => panic!("Unexpected result: {:?}", r)
+            r => panic!("Unexpected result: {:?}", r),
         }
     }
 
@@ -288,7 +316,7 @@ mod test {
         let stat = CgroupCpuStat {
             total_usage: 24000000000,
             user: 16800000000,
-            system: 1200000000
+            system: 1200000000,
         };
 
         let in_percentages = stat.in_percentages();
@@ -310,7 +338,7 @@ mod test {
         let stat = CgroupCpuStat {
             total_usage: 24000000000,
             user: 17100000000,
-            system: 900000000
+            system: 900000000,
         };
 
         let in_percentages = stat.in_percentages();
@@ -329,9 +357,11 @@ mod test {
 
     #[test]
     fn test_in_percentages_integration() {
-        let mut measurement1 = read_and_parse_sys_stat(&Path::new("fixtures/linux/sys/fs/cgroup/cpuacct_1/")).unwrap();
+        let mut measurement1 =
+            read_and_parse_sys_stat(&Path::new("fixtures/linux/sys/fs/cgroup/cpuacct_1/")).unwrap();
         measurement1.precise_time_ns = 375953965125920;
-        let mut measurement2 = read_and_parse_sys_stat(&Path::new("fixtures/linux/sys/fs/cgroup/cpuacct_2/")).unwrap();
+        let mut measurement2 =
+            read_and_parse_sys_stat(&Path::new("fixtures/linux/sys/fs/cgroup/cpuacct_2/")).unwrap();
         measurement2.precise_time_ns = 376013815302920;
 
         let stat = measurement1.calculate_per_minute(&measurement2).unwrap();

--- a/src/cpu/mod.rs
+++ b/src/cpu/mod.rs
@@ -1,2 +1,2 @@
-pub mod proc;
 pub mod cgroup;
+pub mod proc;

--- a/src/cpu/proc.rs
+++ b/src/cpu/proc.rs
@@ -1,10 +1,10 @@
-use super::super::{Result,calculate_time_difference,time_adjusted};
+use super::super::{calculate_time_difference, time_adjusted, Result};
 
 /// Measurement of cpu stats at a certain time
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct CpuMeasurement {
     pub precise_time_ns: u64,
-    pub stat: CpuStat
+    pub stat: CpuStat,
 }
 
 impl CpuMeasurement {
@@ -12,26 +12,82 @@ impl CpuMeasurement {
     /// It is advisable to make the next measurement roughly a minute from this one for the
     /// most reliable result.
     pub fn calculate_per_minute(&self, next_measurement: &CpuMeasurement) -> Result<CpuStat> {
-        let time_difference = calculate_time_difference(self.precise_time_ns, next_measurement.precise_time_ns)?;
+        let time_difference =
+            calculate_time_difference(self.precise_time_ns, next_measurement.precise_time_ns)?;
 
         Ok(CpuStat {
-            total: time_adjusted("total", next_measurement.stat.total, self.stat.total, time_difference)?,
-            user: time_adjusted("user", next_measurement.stat.user, self.stat.user, time_difference)?,
-            nice: time_adjusted("nice", next_measurement.stat.nice, self.stat.nice, time_difference)?,
-            system: time_adjusted("system", next_measurement.stat.system, self.stat.system, time_difference)?,
-            idle: time_adjusted("idle", next_measurement.stat.idle, self.stat.idle, time_difference)?,
-            iowait: time_adjusted("iowait", next_measurement.stat.iowait, self.stat.iowait, time_difference)?,
-            irq: time_adjusted("irq", next_measurement.stat.irq, self.stat.irq, time_difference)?,
-            softirq: time_adjusted("softirq", next_measurement.stat.softirq, self.stat.softirq, time_difference)?,
-            steal: time_adjusted("steal", next_measurement.stat.steal, self.stat.steal, time_difference)?,
-            guest: time_adjusted("guest", next_measurement.stat.guest, self.stat.guest, time_difference)?,
-            guestnice: time_adjusted("guestnice", next_measurement.stat.guestnice, self.stat.guestnice, time_difference)?
+            total: time_adjusted(
+                "total",
+                next_measurement.stat.total,
+                self.stat.total,
+                time_difference,
+            )?,
+            user: time_adjusted(
+                "user",
+                next_measurement.stat.user,
+                self.stat.user,
+                time_difference,
+            )?,
+            nice: time_adjusted(
+                "nice",
+                next_measurement.stat.nice,
+                self.stat.nice,
+                time_difference,
+            )?,
+            system: time_adjusted(
+                "system",
+                next_measurement.stat.system,
+                self.stat.system,
+                time_difference,
+            )?,
+            idle: time_adjusted(
+                "idle",
+                next_measurement.stat.idle,
+                self.stat.idle,
+                time_difference,
+            )?,
+            iowait: time_adjusted(
+                "iowait",
+                next_measurement.stat.iowait,
+                self.stat.iowait,
+                time_difference,
+            )?,
+            irq: time_adjusted(
+                "irq",
+                next_measurement.stat.irq,
+                self.stat.irq,
+                time_difference,
+            )?,
+            softirq: time_adjusted(
+                "softirq",
+                next_measurement.stat.softirq,
+                self.stat.softirq,
+                time_difference,
+            )?,
+            steal: time_adjusted(
+                "steal",
+                next_measurement.stat.steal,
+                self.stat.steal,
+                time_difference,
+            )?,
+            guest: time_adjusted(
+                "guest",
+                next_measurement.stat.guest,
+                self.stat.guest,
+                time_difference,
+            )?,
+            guestnice: time_adjusted(
+                "guestnice",
+                next_measurement.stat.guestnice,
+                self.stat.guestnice,
+                time_difference,
+            )?,
         })
     }
 }
 
 /// Cpu stats for a minute
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct CpuStat {
     pub total: u64,
     pub user: u64,
@@ -43,7 +99,7 @@ pub struct CpuStat {
     pub softirq: u64,
     pub steal: u64,
     pub guest: u64,
-    pub guestnice: u64
+    pub guestnice: u64,
 }
 
 impl CpuStat {
@@ -59,7 +115,7 @@ impl CpuStat {
             softirq: self.percentage_of_total(self.softirq),
             steal: self.percentage_of_total(self.steal),
             guest: self.percentage_of_total(self.guest),
-            guestnice: self.percentage_of_total(self.guestnice)
+            guestnice: self.percentage_of_total(self.guestnice),
         }
     }
 
@@ -69,7 +125,7 @@ impl CpuStat {
 }
 
 /// Cpu stats converted to percentages
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct CpuStatPercentages {
     pub user: f32,
     pub nice: f32,
@@ -80,7 +136,7 @@ pub struct CpuStatPercentages {
     pub softirq: f32,
     pub steal: f32,
     pub guest: f32,
-    pub guestnice: f32
+    pub guestnice: f32,
 }
 
 /// Read the current CPU stats of the system.
@@ -91,12 +147,12 @@ pub fn read() -> Result<CpuMeasurement> {
 
 #[cfg(target_os = "linux")]
 mod os {
-    use std::path::Path;
-    use std::io::BufRead;
-    use time;
-    use super::super::super::{Result,file_to_buf_reader,parse_u64,path_to_string};
-    use super::{CpuMeasurement,CpuStat};
+    use super::super::super::{file_to_buf_reader, parse_u64, path_to_string, Result};
+    use super::{CpuMeasurement, CpuStat};
     use error::ProbeError;
+    use std::io::BufRead;
+    use std::path::Path;
+    use time;
 
     #[inline]
     pub fn read() -> Result<CpuMeasurement> {
@@ -108,16 +164,17 @@ mod os {
         // columns: user nice system idle iowait irq softirq
         let mut reader = file_to_buf_reader(path)?;
         let time = time::precise_time_ns();
-        reader.read_line(&mut line).map_err(|e| ProbeError::IO(e, path_to_string(path)))?;
+        reader
+            .read_line(&mut line)
+            .map_err(|e| ProbeError::IO(e, path_to_string(path)))?;
 
-        let stats: Vec<&str> = line
-            .split_whitespace()
-            .skip(1)
-            .collect();
+        let stats: Vec<&str> = line.split_whitespace().skip(1).collect();
 
         let length = stats.len();
         if length < 5 {
-            return Err(ProbeError::UnexpectedContent("Incorrect number of stats".to_owned()));
+            return Err(ProbeError::UnexpectedContent(
+                "Incorrect number of stats".to_owned(),
+            ));
         }
 
         let usertime = parse_u64(stats[0])?;
@@ -135,8 +192,8 @@ mod os {
             irq: parse_u64(*stats.get(5).unwrap_or(&"0"))?,
             softirq: parse_u64(*stats.get(6).unwrap_or(&"0"))?,
             steal: parse_u64(*stats.get(7).unwrap_or(&"0"))?,
-            guest: guest,
-            guestnice: guestnice
+            guest,
+            guestnice,
         };
         let idlealltime = cpu.idle + cpu.iowait;
         let systemalltime = cpu.system + cpu.irq + cpu.softirq;
@@ -145,17 +202,17 @@ mod os {
 
         Ok(CpuMeasurement {
             precise_time_ns: time,
-            stat: cpu
+            stat: cpu,
         })
     }
 }
 
 #[cfg(test)]
 mod test {
-    use super::{CpuMeasurement,CpuStat,CpuStatPercentages};
     use super::os::read_and_parse_proc_stat;
-    use std::path::Path;
+    use super::{CpuMeasurement, CpuStat, CpuStatPercentages};
     use error::ProbeError;
+    use std::path::Path;
 
     #[test]
     fn test_read_cpu() {
@@ -164,7 +221,8 @@ mod test {
 
     #[test]
     fn test_read_proc_measurement() {
-        let measurement = read_and_parse_proc_stat(&Path::new("fixtures/linux/cpu/proc_stat")).unwrap();
+        let measurement =
+            read_and_parse_proc_stat(&Path::new("fixtures/linux/cpu/proc_stat")).unwrap();
         let cpu = measurement.stat;
         assert_eq!(cpu.total, 39);
         assert_eq!(cpu.user, 8);
@@ -181,7 +239,8 @@ mod test {
 
     #[test]
     fn test_read_proc_measurement_from_partial() {
-        let measurement = read_and_parse_proc_stat(&Path::new("fixtures/linux/cpu/proc_stat_partial")).unwrap();
+        let measurement =
+            read_and_parse_proc_stat(&Path::new("fixtures/linux/cpu/proc_stat_partial")).unwrap();
         let cpu = measurement.stat;
         assert_eq!(cpu.total, 31);
         assert_eq!(cpu.user, 10);
@@ -200,7 +259,7 @@ mod test {
     fn test_proc_wrong_path() {
         match read_and_parse_proc_stat(&Path::new("bananas")) {
             Err(ProbeError::IO(_, _)) => (),
-            r => panic!("Unexpected result: {:?}", r)
+            r => panic!("Unexpected result: {:?}", r),
         }
     }
 
@@ -208,7 +267,7 @@ mod test {
     fn test_read_and_parse_proc_stat_incomplete() {
         match read_and_parse_proc_stat(&Path::new("fixtures/linux/cpu/proc_stat_incomplete")) {
             Err(ProbeError::UnexpectedContent(_)) => (),
-            r => panic!("Unexpected result: {:?}", r)
+            r => panic!("Unexpected result: {:?}", r),
         }
     }
 
@@ -217,7 +276,7 @@ mod test {
         let path = Path::new("fixtures/linux/cpu/proc_stat_garbage");
         match read_and_parse_proc_stat(&path) {
             Err(ProbeError::UnexpectedContent(_)) => (),
-            r => panic!("Unexpected result: {:?}", r)
+            r => panic!("Unexpected result: {:?}", r),
         }
     }
 
@@ -236,8 +295,8 @@ mod test {
                 softirq: 0,
                 steal: 0,
                 guest: 0,
-                guestnice: 0
-            }
+                guestnice: 0,
+            },
         };
 
         let measurement2 = CpuMeasurement {
@@ -253,13 +312,13 @@ mod test {
                 softirq: 0,
                 steal: 0,
                 guest: 0,
-                guestnice: 0
-            }
+                guestnice: 0,
+            },
         };
 
         match measurement1.calculate_per_minute(&measurement2) {
             Err(ProbeError::InvalidInput(_)) => (),
-            r => panic!("Unexpected result: {:?}", r)
+            r => panic!("Unexpected result: {:?}", r),
         }
     }
 
@@ -278,8 +337,8 @@ mod test {
                 softirq: 10,
                 steal: 20,
                 guest: 200,
-                guestnice: 100
-            }
+                guestnice: 100,
+            },
         };
 
         let measurement2 = CpuMeasurement {
@@ -295,8 +354,8 @@ mod test {
                 softirq: 16,
                 steal: 26,
                 guest: 206,
-                guestnice: 106
-            }
+                guestnice: 106,
+            },
         };
 
         let expected = CpuStat {
@@ -310,7 +369,7 @@ mod test {
             softirq: 6,
             steal: 6,
             guest: 6,
-            guestnice: 6
+            guestnice: 6,
         };
 
         let stat = measurement1.calculate_per_minute(&measurement2).unwrap();
@@ -333,8 +392,8 @@ mod test {
                 softirq: 10,
                 steal: 20,
                 guest: 200,
-                guestnice: 100
-            }
+                guestnice: 100,
+            },
         };
 
         let measurement2 = CpuMeasurement {
@@ -350,8 +409,8 @@ mod test {
                 softirq: 16,
                 steal: 26,
                 guest: 206,
-                guestnice: 106
-            }
+                guestnice: 106,
+            },
         };
 
         let expected = CpuStat {
@@ -365,7 +424,7 @@ mod test {
             softirq: 12,
             steal: 12,
             guest: 12,
-            guestnice: 12
+            guestnice: 12,
         };
 
         let stat = measurement1.calculate_per_minute(&measurement2).unwrap();
@@ -388,8 +447,8 @@ mod test {
                 softirq: 10,
                 steal: 20,
                 guest: 200,
-                guestnice: 100
-            }
+                guestnice: 100,
+            },
         };
 
         let measurement2 = CpuMeasurement {
@@ -405,13 +464,13 @@ mod test {
                 softirq: 16,
                 steal: 26,
                 guest: 206,
-                guestnice: 106
-            }
+                guestnice: 106,
+            },
         };
 
         match measurement1.calculate_per_minute(&measurement2) {
             Err(ProbeError::UnexpectedContent(_)) => (),
-            r => panic!("Unexpected result: {:?}", r)
+            r => panic!("Unexpected result: {:?}", r),
         }
     }
 
@@ -428,7 +487,7 @@ mod test {
             softirq: 20,
             steal: 50,
             guest: 50,
-            guestnice: 30
+            guestnice: 30,
         };
 
         let expected = CpuStatPercentages {
@@ -441,7 +500,7 @@ mod test {
             softirq: 2.0,
             steal: 5.0,
             guest: 5.0,
-            guestnice: 3.0
+            guestnice: 3.0,
         };
 
         assert_eq!(stat.in_percentages(), expected);
@@ -460,7 +519,7 @@ mod test {
             softirq: 2,
             steal: 50,
             guest: 55,
-            guestnice: 35
+            guestnice: 35,
         };
 
         let expected = CpuStatPercentages {
@@ -473,7 +532,7 @@ mod test {
             softirq: 0.2,
             steal: 5.0,
             guest: 5.5,
-            guestnice: 3.5
+            guestnice: 3.5,
         };
 
         assert_eq!(stat.in_percentages(), expected);
@@ -481,9 +540,11 @@ mod test {
 
     #[test]
     fn test_in_percentages_integration() {
-        let mut measurement1 = read_and_parse_proc_stat(&Path::new("fixtures/linux/cpu/proc_stat_1")).unwrap();
+        let mut measurement1 =
+            read_and_parse_proc_stat(&Path::new("fixtures/linux/cpu/proc_stat_1")).unwrap();
         measurement1.precise_time_ns = 60_000_000_000;
-        let mut measurement2 = read_and_parse_proc_stat(&Path::new("fixtures/linux/cpu/proc_stat_2")).unwrap();
+        let mut measurement2 =
+            read_and_parse_proc_stat(&Path::new("fixtures/linux/cpu/proc_stat_2")).unwrap();
         measurement2.precise_time_ns = 120_000_000_000;
 
         let stat = measurement1.calculate_per_minute(&measurement2).unwrap();
@@ -526,7 +587,12 @@ mod test {
         let idlealltime = in_percentages.idle + in_percentages.iowait;
         let systemalltime = in_percentages.system + in_percentages.irq + in_percentages.softirq;
         let virtualtime = in_percentages.guest + in_percentages.guestnice;
-        let total = (in_percentages.user + in_percentages.nice + systemalltime + idlealltime + in_percentages.steal + virtualtime) as f64;
+        let total = (in_percentages.user
+            + in_percentages.nice
+            + systemalltime
+            + idlealltime
+            + in_percentages.steal
+            + virtualtime) as f64;
 
         assert!(total < 100.1);
         assert!(total > 99.9);

--- a/src/disk_stats.rs
+++ b/src/disk_stats.rs
@@ -1,55 +1,117 @@
+use super::{calculate_time_difference, time_adjusted, Result};
+use error::ProbeError;
 use std::collections::HashMap;
 use std::path::Path;
-use super::{Result,time_adjusted,calculate_time_difference};
-use error::ProbeError;
 
 pub type DiskStats = HashMap<String, DiskStat>;
 
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct DiskStatsMeasurement {
     pub precise_time_ns: u64,
-    pub stats: DiskStats
+    pub stats: DiskStats,
 }
 
 impl DiskStatsMeasurement {
     /// Calculate the disk stats per minute based on this measurement and a measurement in the
     /// future. It is advisable to make the next measurement roughly a minute from this one for the
     /// most reliable result.
-    pub fn calculate_per_minute(&self, next_measurement: &DiskStatsMeasurement) -> Result<DiskStatsPerMinute> {
-        let time_difference = calculate_time_difference(self.precise_time_ns, next_measurement.precise_time_ns)?;
+    pub fn calculate_per_minute(
+        &self,
+        next_measurement: &DiskStatsMeasurement,
+    ) -> Result<DiskStatsPerMinute> {
+        let time_difference =
+            calculate_time_difference(self.precise_time_ns, next_measurement.precise_time_ns)?;
 
         let mut stats = HashMap::new();
 
         for (name, stat) in self.stats.iter() {
             let next_stat = match next_measurement.stats.get(name) {
                 Some(stat) => stat,
-                None => return Err(ProbeError::UnexpectedContent(format!("{} is not present in the next measurement", name)))
+                None => {
+                    return Err(ProbeError::UnexpectedContent(format!(
+                        "{} is not present in the next measurement",
+                        name
+                    )))
+                }
             };
             stats.insert(
                 name.to_owned(),
                 DiskStat {
-                    reads_completed_successfully: time_adjusted("reads_completed_successfully", next_stat.reads_completed_successfully, stat.reads_completed_successfully, time_difference)?,
-                    reads_merged: time_adjusted("reads_merged", next_stat.reads_merged, stat.reads_merged, time_difference)?,
-                    sectors_read: time_adjusted("sectors_read", next_stat.sectors_read, stat.sectors_read, time_difference)?,
-                    time_spent_reading_ms: time_adjusted("time_spent_reading_ms", next_stat.time_spent_reading_ms, stat.time_spent_reading_ms, time_difference)?,
-                    writes_completed: time_adjusted("writes_completed", next_stat.writes_completed, stat.writes_completed, time_difference)?,
-                    writes_merged: time_adjusted("writes_merged", next_stat.writes_merged, stat.writes_merged, time_difference)?,
-                    sectors_written: time_adjusted("sectors_written", next_stat.sectors_written, stat.sectors_written, time_difference)?,
-                    time_spent_writing_ms: time_adjusted("time_spent_writing_ms", next_stat.time_spent_writing_ms, stat.time_spent_writing_ms, time_difference)?,
-                    ios_currently_in_progress: time_adjusted("ios_currently_in_progress", next_stat.ios_currently_in_progress, stat.ios_currently_in_progress, time_difference)?,
-                    time_spent_doing_ios_ms: time_adjusted("time_spent_doing_ios_ms", next_stat.time_spent_doing_ios_ms, stat.time_spent_doing_ios_ms, time_difference)?,
-                    weighted_time_spent_doing_ios_ms: time_adjusted("weighted_time_spent_doing_ios_ms", next_stat.weighted_time_spent_doing_ios_ms, stat.weighted_time_spent_doing_ios_ms, time_difference)?
-                }
+                    reads_completed_successfully: time_adjusted(
+                        "reads_completed_successfully",
+                        next_stat.reads_completed_successfully,
+                        stat.reads_completed_successfully,
+                        time_difference,
+                    )?,
+                    reads_merged: time_adjusted(
+                        "reads_merged",
+                        next_stat.reads_merged,
+                        stat.reads_merged,
+                        time_difference,
+                    )?,
+                    sectors_read: time_adjusted(
+                        "sectors_read",
+                        next_stat.sectors_read,
+                        stat.sectors_read,
+                        time_difference,
+                    )?,
+                    time_spent_reading_ms: time_adjusted(
+                        "time_spent_reading_ms",
+                        next_stat.time_spent_reading_ms,
+                        stat.time_spent_reading_ms,
+                        time_difference,
+                    )?,
+                    writes_completed: time_adjusted(
+                        "writes_completed",
+                        next_stat.writes_completed,
+                        stat.writes_completed,
+                        time_difference,
+                    )?,
+                    writes_merged: time_adjusted(
+                        "writes_merged",
+                        next_stat.writes_merged,
+                        stat.writes_merged,
+                        time_difference,
+                    )?,
+                    sectors_written: time_adjusted(
+                        "sectors_written",
+                        next_stat.sectors_written,
+                        stat.sectors_written,
+                        time_difference,
+                    )?,
+                    time_spent_writing_ms: time_adjusted(
+                        "time_spent_writing_ms",
+                        next_stat.time_spent_writing_ms,
+                        stat.time_spent_writing_ms,
+                        time_difference,
+                    )?,
+                    ios_currently_in_progress: time_adjusted(
+                        "ios_currently_in_progress",
+                        next_stat.ios_currently_in_progress,
+                        stat.ios_currently_in_progress,
+                        time_difference,
+                    )?,
+                    time_spent_doing_ios_ms: time_adjusted(
+                        "time_spent_doing_ios_ms",
+                        next_stat.time_spent_doing_ios_ms,
+                        stat.time_spent_doing_ios_ms,
+                        time_difference,
+                    )?,
+                    weighted_time_spent_doing_ios_ms: time_adjusted(
+                        "weighted_time_spent_doing_ios_ms",
+                        next_stat.weighted_time_spent_doing_ios_ms,
+                        stat.weighted_time_spent_doing_ios_ms,
+                        time_difference,
+                    )?,
+                },
             );
         }
 
-        Ok(DiskStatsPerMinute {
-            stats: stats
-        })
+        Ok(DiskStatsPerMinute { stats })
     }
 }
 
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct DiskStat {
     pub reads_completed_successfully: u64,
     pub reads_merged: u64,
@@ -61,7 +123,7 @@ pub struct DiskStat {
     pub time_spent_writing_ms: u64,
     pub ios_currently_in_progress: u64,
     pub time_spent_doing_ios_ms: u64,
-    pub weighted_time_spent_doing_ios_ms: u64
+    pub weighted_time_spent_doing_ios_ms: u64,
 }
 
 impl DiskStat {
@@ -74,9 +136,9 @@ impl DiskStat {
     }
 }
 
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct DiskStatsPerMinute {
-   pub stats: DiskStats
+    pub stats: DiskStats,
 }
 
 #[cfg(target_os = "linux")]
@@ -86,12 +148,12 @@ pub fn read() -> Result<DiskStatsMeasurement> {
 
 #[cfg(target_os = "linux")]
 mod os {
+    use super::super::{file_to_buf_reader, parse_u64, path_to_string, ProbeError, Result};
+    use super::{DiskStat, DiskStatsMeasurement};
+    use std::collections::HashMap;
     use std::io::BufRead;
     use std::path::Path;
-    use std::collections::HashMap;
     use time;
-    use super::{DiskStatsMeasurement,DiskStat};
-    use super::super::{file_to_buf_reader,parse_u64,Result,ProbeError,path_to_string};
 
     #[inline]
     pub fn read_and_parse_proc_diskstats(path: &Path) -> Result<DiskStatsMeasurement> {
@@ -99,7 +161,7 @@ mod os {
 
         let mut out = DiskStatsMeasurement {
             precise_time_ns: time::precise_time_ns(),
-            stats: HashMap::new()
+            stats: HashMap::new(),
         };
 
         for line_result in reader.lines() {
@@ -108,7 +170,9 @@ mod os {
 
             // /proc/disktats has 14 fields, or 18 fields for kernel 4.18+
             if segments.len() != 14 && segments.len() != 18 {
-                return Err(ProbeError::UnexpectedContent("Incorrect number of segments".to_owned()))
+                return Err(ProbeError::UnexpectedContent(
+                    "Incorrect number of segments".to_owned(),
+                ));
             }
 
             let disk_stat = DiskStat {
@@ -122,7 +186,7 @@ mod os {
                 time_spent_writing_ms: parse_u64(segments[10])?,
                 ios_currently_in_progress: parse_u64(segments[11])?,
                 time_spent_doing_ios_ms: parse_u64(segments[12])?,
-                weighted_time_spent_doing_ios_ms: parse_u64(segments[13])?
+                weighted_time_spent_doing_ios_ms: parse_u64(segments[13])?,
             };
             out.stats.insert(segments[2].to_owned(), disk_stat);
         }
@@ -133,11 +197,11 @@ mod os {
 
 #[cfg(test)]
 mod tests {
+    use super::os::read_and_parse_proc_diskstats;
+    use super::DiskStatsMeasurement;
+    use error::ProbeError;
     use std::collections::HashMap;
     use std::path::Path;
-    use error::ProbeError;
-    use super::DiskStatsMeasurement;
-    use super::os::read_and_parse_proc_diskstats;
 
     #[test]
     fn test_read_disk_stats() {
@@ -146,7 +210,9 @@ mod tests {
 
     #[test]
     fn test_read_and_parse_proc_diskstats() {
-        let measurement = read_and_parse_proc_diskstats(&Path::new("fixtures/linux/disk_stats/proc_diskstats")).unwrap();
+        let measurement =
+            read_and_parse_proc_diskstats(&Path::new("fixtures/linux/disk_stats/proc_diskstats"))
+                .unwrap();
 
         assert!(measurement.precise_time_ns > 0);
 
@@ -185,7 +251,10 @@ mod tests {
 
     #[test]
     fn test_read_and_parse_proc_diskstats_kernel_4_18_plus() {
-        let measurement = read_and_parse_proc_diskstats(&Path::new("fixtures/linux/disk_stats/proc_diskstats_4_18")).unwrap();
+        let measurement = read_and_parse_proc_diskstats(&Path::new(
+            "fixtures/linux/disk_stats/proc_diskstats_4_18",
+        ))
+        .unwrap();
 
         assert!(measurement.precise_time_ns > 0);
 
@@ -224,17 +293,21 @@ mod tests {
 
     #[test]
     fn test_read_and_parse_proc_diskstats_incomplete() {
-        match read_and_parse_proc_diskstats(&Path::new("fixtures/linux/disk_stats/proc_diskstats_incomplete")) {
+        match read_and_parse_proc_diskstats(&Path::new(
+            "fixtures/linux/disk_stats/proc_diskstats_incomplete",
+        )) {
             Err(ProbeError::UnexpectedContent(_)) => (),
-            r => panic!("Unexpected result: {:?}", r)
+            r => panic!("Unexpected result: {:?}", r),
         }
     }
 
     #[test]
     fn test_read_and_parse_proc_diskstats_garbage() {
-        match read_and_parse_proc_diskstats(&Path::new("fixtures/linux/disk_stats/proc_diskstats_garbage")) {
+        match read_and_parse_proc_diskstats(&Path::new(
+            "fixtures/linux/disk_stats/proc_diskstats_garbage",
+        )) {
             Err(ProbeError::UnexpectedContent(_)) => (),
-            r => panic!("Unexpected result: {:?}", r)
+            r => panic!("Unexpected result: {:?}", r),
         }
     }
 
@@ -244,13 +317,13 @@ mod tests {
         stats1.insert("sda1".to_owned(), helpers::disk_stat(0));
         let measurement1 = DiskStatsMeasurement {
             precise_time_ns: 60_000_000_000,
-            stats: stats1
+            stats: stats1,
         };
         let mut stats2 = HashMap::new();
         stats2.insert("sda1".to_owned(), helpers::disk_stat(120));
         let measurement2 = DiskStatsMeasurement {
             precise_time_ns: 120_000_000_000,
-            stats: stats2
+            stats: stats2,
         };
 
         let per_minute = measurement1.calculate_per_minute(&measurement2).unwrap();
@@ -274,13 +347,13 @@ mod tests {
         stats1.insert("sda1".to_owned(), helpers::disk_stat(0));
         let measurement1 = DiskStatsMeasurement {
             precise_time_ns: 60_000_000_000,
-            stats: stats1
+            stats: stats1,
         };
         let mut stats2 = HashMap::new();
         stats2.insert("sda1".to_owned(), helpers::disk_stat(120));
         let measurement2 = DiskStatsMeasurement {
             precise_time_ns: 90_000_000_000,
-            stats: stats2
+            stats: stats2,
         };
 
         let per_minute = measurement1.calculate_per_minute(&measurement2).unwrap();
@@ -302,16 +375,16 @@ mod tests {
     fn test_calculate_per_minute_wrong_times() {
         let measurement1 = DiskStatsMeasurement {
             precise_time_ns: 500,
-            stats: HashMap::new()
+            stats: HashMap::new(),
         };
         let measurement2 = DiskStatsMeasurement {
             precise_time_ns: 300,
-            stats: HashMap::new()
+            stats: HashMap::new(),
         };
 
         match measurement1.calculate_per_minute(&measurement2) {
             Err(ProbeError::InvalidInput(_)) => (),
-            r => panic!("Unexpected result: {:?}", r)
+            r => panic!("Unexpected result: {:?}", r),
         }
     }
 
@@ -321,18 +394,18 @@ mod tests {
         stats1.insert("sda1".to_owned(), helpers::disk_stat(500));
         let measurement1 = DiskStatsMeasurement {
             precise_time_ns: 500,
-            stats: stats1
+            stats: stats1,
         };
         let mut stats2 = HashMap::new();
         stats2.insert("sda1".to_owned(), helpers::disk_stat(400));
         let measurement2 = DiskStatsMeasurement {
             precise_time_ns: 600,
-            stats: stats2
+            stats: stats2,
         };
 
         match measurement1.calculate_per_minute(&measurement2) {
             Err(ProbeError::UnexpectedContent(_)) => (),
-            r => panic!("Unexpected result: {:?}", r)
+            r => panic!("Unexpected result: {:?}", r),
         }
     }
 
@@ -342,18 +415,18 @@ mod tests {
         stats1.insert("sda1".to_owned(), helpers::disk_stat(500));
         let measurement1 = DiskStatsMeasurement {
             precise_time_ns: 500,
-            stats: stats1
+            stats: stats1,
         };
         let mut stats2 = HashMap::new();
         stats2.insert("sda2".to_owned(), helpers::disk_stat(600));
         let measurement2 = DiskStatsMeasurement {
             precise_time_ns: 600,
-            stats: stats2
+            stats: stats2,
         };
 
         match measurement1.calculate_per_minute(&measurement2) {
             Err(ProbeError::UnexpectedContent(_)) => (),
-            r => panic!("Unexpected result: {:?}", r)
+            r => panic!("Unexpected result: {:?}", r),
         }
     }
 
@@ -372,7 +445,7 @@ mod tests {
                 time_spent_writing_ms: value,
                 ios_currently_in_progress: value,
                 time_spent_doing_ios_ms: value,
-                weighted_time_spent_doing_ios_ms: value
+                weighted_time_spent_doing_ios_ms: value,
             }
         }
     }

--- a/src/disk_usage.rs
+++ b/src/disk_usage.rs
@@ -2,14 +2,14 @@ use super::Result;
 
 pub type DiskUsages = Vec<DiskUsage>;
 
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct DiskUsage {
     pub filesystem: Option<String>,
     pub one_k_blocks: u64,
     pub one_k_blocks_used: u64,
     pub one_k_blocks_free: u64,
     pub used_percentage: u32,
-    pub mountpoint: String
+    pub mountpoint: String,
 }
 
 /// Read the current usage of all disks
@@ -20,9 +20,9 @@ pub fn read() -> Result<DiskUsages> {
 
 #[cfg(target_os = "linux")]
 mod os {
+    use super::super::{parse_u64, ProbeError, Result};
+    use super::{DiskUsage, DiskUsages};
     use std::process::Command;
-    use super::{DiskUsages,DiskUsage};
-    use super::super::{ProbeError,Result,parse_u64};
 
     #[inline]
     pub fn read() -> Result<DiskUsages> {
@@ -38,7 +38,7 @@ mod os {
 
     #[inline]
     pub fn parse_df_output(output: &str) -> Result<DiskUsages> {
-        let lines = output.split("\n");
+        let lines = output.split('\n');
 
         let mut out: DiskUsages = Vec::new();
 
@@ -56,16 +56,16 @@ mod os {
                 // Get filesystem
                 let filesystem = match segments[0] {
                     "none" => None,
-                    value => Some(value.to_string())
+                    value => Some(value.to_string()),
                 };
 
                 let disk = DiskUsage {
-                    filesystem: filesystem,
+                    filesystem,
                     one_k_blocks: parse_u64(segments[1])?,
                     one_k_blocks_used: parse_u64(segments[2])?,
                     one_k_blocks_free: parse_u64(segments[3])?,
                     used_percentage: parse_percentage_segment(&segments[4])?,
-                    mountpoint: segments[5].to_string()
+                    mountpoint: segments[5].to_string(),
                 };
 
                 out.push(disk);
@@ -77,22 +77,24 @@ mod os {
                         // Get filesystem
                         let filesystem = match previous_filesystem.as_ref() {
                             "none" => None,
-                            value => Some(value.to_string())
+                            value => Some(value.to_string()),
                         };
 
                         let disk = DiskUsage {
-                            filesystem: filesystem,
+                            filesystem,
                             one_k_blocks: parse_u64(segments[0])?,
                             one_k_blocks_used: parse_u64(segments[1])?,
                             one_k_blocks_free: parse_u64(segments[2])?,
                             used_percentage: parse_percentage_segment(&segments[3])?,
-                            mountpoint: segments[4].to_string()
+                            mountpoint: segments[4].to_string(),
                         };
 
                         out.push(disk);
-                    },
+                    }
                     None => {
-                        return Err(ProbeError::UnexpectedContent("filesystem expected on previous line".to_owned()))
+                        return Err(ProbeError::UnexpectedContent(
+                            "filesystem expected on previous line".to_owned(),
+                        ))
                     }
                 }
 
@@ -101,7 +103,9 @@ mod os {
             } else if segments_len == 0 {
                 // Skip
             } else {
-                return Err(ProbeError::UnexpectedContent("Incorrect number of segments".to_owned()))
+                return Err(ProbeError::UnexpectedContent(
+                    "Incorrect number of segments".to_owned(),
+                ));
             }
         }
 
@@ -111,7 +115,7 @@ mod os {
     #[inline]
     fn parse_percentage_segment(segment: &str) -> Result<u32> {
         // Strip % from the used value
-        let segment_minus_percentage = &segment[..segment.len() -1];
+        let segment_minus_percentage = &segment[..segment.len() - 1];
         segment_minus_percentage.parse().map_err(|_| {
             ProbeError::UnexpectedContent("Could not parse percentage segment".to_owned())
         })
@@ -120,10 +124,10 @@ mod os {
 
 #[cfg(test)]
 mod tests {
-    use std::path::Path;
     use super::super::file_to_string;
     use super::super::ProbeError;
     use super::DiskUsage;
+    use std::path::Path;
 
     #[test]
     fn test_read_disks() {
@@ -140,7 +144,7 @@ mod tests {
                 one_k_blocks_used: 2344444,
                 one_k_blocks_free: 74763732,
                 used_percentage: 4,
-                mountpoint: "/".to_owned()
+                mountpoint: "/".to_owned(),
             },
             DiskUsage {
                 filesystem: None,
@@ -148,7 +152,7 @@ mod tests {
                 one_k_blocks_used: 180,
                 one_k_blocks_free: 182996,
                 used_percentage: 1,
-                mountpoint: "/dev".to_owned()
+                mountpoint: "/dev".to_owned(),
             },
             DiskUsage {
                 filesystem: Some("/dev/sda1".to_owned()),
@@ -156,8 +160,8 @@ mod tests {
                 one_k_blocks_used: 17217,
                 one_k_blocks_free: 203533,
                 used_percentage: 8,
-                mountpoint: "/boot".to_owned()
-            }
+                mountpoint: "/boot".to_owned(),
+            },
         ];
 
         let df = file_to_string(Path::new("fixtures/linux/disk_usage/df")).unwrap();
@@ -171,7 +175,7 @@ mod tests {
         let df = file_to_string(Path::new("fixtures/linux/disk_usage/df_incomplete")).unwrap();
         match super::os::parse_df_output(&df) {
             Err(ProbeError::UnexpectedContent(_)) => (),
-            r => panic!("Unexpected result: {:?}", r)
+            r => panic!("Unexpected result: {:?}", r),
         }
     }
 
@@ -180,7 +184,7 @@ mod tests {
         let df = file_to_string(Path::new("fixtures/linux/disk_usage/df_garbage")).unwrap();
         match super::os::parse_df_output(&df) {
             Err(ProbeError::UnexpectedContent(_)) => (),
-            r => panic!("Unexpected result: {:?}", r)
+            r => panic!("Unexpected result: {:?}", r),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,6 @@
 use std::error;
-use std::io;
 use std::fmt;
+use std::io;
 
 #[derive(Debug)]
 pub enum ProbeError {
@@ -10,7 +10,7 @@ pub enum ProbeError {
     /// Unexpected content in file or output
     UnexpectedContent(String),
     /// Input into a calculation function is invalid
-    InvalidInput(String)
+    InvalidInput(String),
 }
 
 impl fmt::Display for ProbeError {
@@ -18,7 +18,7 @@ impl fmt::Display for ProbeError {
         match *self {
             ProbeError::IO(ref err, ref path) => write!(f, "{} for {}", err, path),
             ProbeError::UnexpectedContent(ref err) => write!(f, "{}", err),
-            ProbeError::InvalidInput(ref err) => write!(f, "{}", err)
+            ProbeError::InvalidInput(ref err) => write!(f, "{}", err),
         }
     }
 }
@@ -26,17 +26,18 @@ impl fmt::Display for ProbeError {
 impl error::Error for ProbeError {
     fn description(&self) -> &str {
         match *self {
+            #[allow(deprecated)]
             ProbeError::IO(ref err, ref _path) => err.description(),
             ProbeError::UnexpectedContent(ref err) => err,
-            ProbeError::InvalidInput(ref err) => err
+            ProbeError::InvalidInput(ref err) => err,
         }
     }
 
-    fn cause(&self) -> Option<&error::Error> {
+    fn cause(&self) -> Option<&dyn error::Error> {
         match *self {
             ProbeError::IO(ref err, ref _path) => Some(err),
             ProbeError::UnexpectedContent(_) => None,
-            ProbeError::InvalidInput(_) => None
+            ProbeError::InvalidInput(_) => None,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,10 @@
 extern crate libc;
 extern crate time;
 
-mod error;
 pub mod cpu;
 pub mod disk_stats;
 pub mod disk_usage;
+mod error;
 pub mod load;
 pub mod memory;
 pub mod network;
@@ -12,8 +12,8 @@ pub mod process_memory;
 
 use std::fs;
 use std::io;
-use std::io::Read;
 use std::io::BufRead;
+use std::io::Read;
 use std::path::Path;
 use std::result;
 
@@ -23,11 +23,9 @@ pub type Result<T> = result::Result<T, error::ProbeError>;
 
 #[inline]
 fn file_to_string(path: &Path) -> Result<String> {
-    let mut file = fs::File::open(path)
-        .map_err(|e| ProbeError::IO(e, path_to_string(path)))?;
+    let mut file = fs::File::open(path).map_err(|e| ProbeError::IO(e, path_to_string(path)))?;
     let mut read = String::new();
-    file
-        .read_to_string(&mut read)
+    file.read_to_string(&mut read)
         .map_err(|e| ProbeError::IO(e, path_to_string(path)))?;
     Ok(read)
 }
@@ -47,26 +45,40 @@ fn path_to_string(path: &Path) -> String {
 #[inline]
 fn calculate_time_difference(first_time: u64, second_time: u64) -> Result<u64> {
     if first_time > second_time {
-        Err(ProbeError::InvalidInput(format!("first time {} was after second time {}", first_time, second_time)))
+        Err(ProbeError::InvalidInput(format!(
+            "first time {} was after second time {}",
+            first_time, second_time
+        )))
     } else {
         Ok(second_time - first_time)
     }
 }
 
 #[inline]
-fn time_adjusted(field_name: &str, first_value: u64, second_value: u64, time_difference_ns: u64) -> Result<u64> {
+fn time_adjusted(
+    field_name: &str,
+    first_value: u64,
+    second_value: u64,
+    time_difference_ns: u64,
+) -> Result<u64> {
     if first_value < second_value {
-        Err(ProbeError::UnexpectedContent(format!("First value {} was lower than second value {} for '{}'", first_value, second_value, field_name)))
+        Err(ProbeError::UnexpectedContent(format!(
+            "First value {} was lower than second value {} for '{}'",
+            first_value, second_value, field_name
+        )))
     } else {
-        Ok(((first_value - second_value) as f64 / time_difference_ns as f64 * 60_000_000_000.0) as u64)
+        Ok(
+            ((first_value - second_value) as f64 / time_difference_ns as f64 * 60_000_000_000.0)
+                as u64,
+        )
     }
 }
 
 #[inline]
 fn parse_u64(segment: &str) -> Result<u64> {
-    segment.parse().map_err(|_| {
-        ProbeError::UnexpectedContent(format!("Could not parse '{}' as u64", segment).to_owned())
-    })
+    segment
+        .parse()
+        .map_err(|_| ProbeError::UnexpectedContent(format!("Could not parse '{}' as u64", segment)))
 }
 
 #[inline]
@@ -76,9 +88,11 @@ fn dir_exists(path: &Path) -> bool {
 
 #[inline]
 fn read_file_value_as_u64(path: &Path) -> Result<u64> {
-    let mut reader = try!(file_to_buf_reader(path));
+    let mut reader = file_to_buf_reader(path)?;
     let mut line = String::new();
-    reader.read_line(&mut line).map_err(|e| ProbeError::IO(e, path_to_string(path)))?;
+    reader
+        .read_line(&mut line)
+        .map_err(|e| ProbeError::IO(e, path_to_string(path)))?;
     parse_u64(&line.trim())
 }
 
@@ -94,16 +108,25 @@ mod tests {
 
     #[test]
     fn test_time_adjusted() {
-        assert_eq!(1200, super::time_adjusted("field", 2400, 1200, 60_000_000_000).unwrap());
-        assert_eq!(2400, super::time_adjusted("field", 2400, 1200, 30_000_000_000).unwrap());
-        assert_eq!(4800, super::time_adjusted("field", 2400, 1200, 15_000_000_000).unwrap());
+        assert_eq!(
+            1200,
+            super::time_adjusted("field", 2400, 1200, 60_000_000_000).unwrap()
+        );
+        assert_eq!(
+            2400,
+            super::time_adjusted("field", 2400, 1200, 30_000_000_000).unwrap()
+        );
+        assert_eq!(
+            4800,
+            super::time_adjusted("field", 2400, 1200, 15_000_000_000).unwrap()
+        );
     }
 
     #[test]
     fn test_time_adjusted_first_higher_than_lower() {
         match super::time_adjusted("field", 1200, 2400, 60_000_000_000) {
             Err(ProbeError::UnexpectedContent(_)) => (),
-            r => panic!("Unexpected result: {:?}", r)
+            r => panic!("Unexpected result: {:?}", r),
         }
     }
 

--- a/src/load.rs
+++ b/src/load.rs
@@ -1,10 +1,10 @@
 use super::Result;
 
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct LoadAverage {
-    pub one:     f32,
-    pub five:    f32,
-    pub fifteen: f32
+    pub one: f32,
+    pub five: f32,
+    pub fifteen: f32,
 }
 
 /// Read the current load average of the system.
@@ -17,10 +17,10 @@ pub fn read() -> Result<LoadAverage> {
 mod os {
     use std::path::Path;
 
-    use super::LoadAverage;
+    use super::super::file_to_string;
     use super::super::ProbeError;
     use super::super::Result;
-    use super::super::file_to_string;
+    use super::LoadAverage;
 
     #[inline]
     pub fn read() -> Result<LoadAverage> {
@@ -33,29 +33,31 @@ mod os {
         let segments: Vec<&str> = raw_data.split_whitespace().collect();
 
         if segments.len() < 3 {
-            return Err(ProbeError::UnexpectedContent("Incorrect number of segments".to_owned()))
+            return Err(ProbeError::UnexpectedContent(
+                "Incorrect number of segments".to_owned(),
+            ));
         }
 
         Ok(LoadAverage {
-            one:     parse_segment(segments[0])?,
-            five:    parse_segment(segments[1])?,
-            fifteen: parse_segment(segments[2])?
+            one: parse_segment(segments[0])?,
+            five: parse_segment(segments[1])?,
+            fifteen: parse_segment(segments[2])?,
         })
     }
 
     #[inline]
     fn parse_segment(segment: &str) -> Result<f32> {
-        segment.parse().map_err(|_| {
-            ProbeError::UnexpectedContent("Could not parse segment".to_owned())
-        })
+        segment
+            .parse()
+            .map_err(|_| ProbeError::UnexpectedContent("Could not parse segment".to_owned()))
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::path::Path;
     use super::super::ProbeError;
     use super::LoadAverage;
+    use std::path::Path;
 
     #[test]
     fn test_read_load_average() {
@@ -70,7 +72,7 @@ mod tests {
         let expected = LoadAverage {
             one: 0.01,
             five: 0.02,
-            fifteen: 0.03
+            fifteen: 0.03,
         };
 
         assert_eq!(expected, load_average);
@@ -81,7 +83,7 @@ mod tests {
         let path = Path::new("/nonsense");
         match super::os::read_and_parse_load_average(&path) {
             Err(ProbeError::IO(_, _)) => (),
-            r => panic!("Unexpected result: {:?}", r)
+            r => panic!("Unexpected result: {:?}", r),
         }
     }
 
@@ -90,7 +92,7 @@ mod tests {
         let path = Path::new("fixtures/linux/load/proc_loadavg_incomplete");
         match super::os::read_and_parse_load_average(&path) {
             Err(ProbeError::UnexpectedContent(_)) => (),
-            r => panic!("Unexpected result: {:?}", r)
+            r => panic!("Unexpected result: {:?}", r),
         }
     }
 
@@ -99,7 +101,7 @@ mod tests {
         let path = Path::new("fixtures/linux/load/proc_loadavg_garbage");
         match super::os::read_and_parse_load_average(&path) {
             Err(ProbeError::UnexpectedContent(_)) => (),
-            r => panic!("Unexpected result: {:?}", r)
+            r => panic!("Unexpected result: {:?}", r),
         }
     }
 }

--- a/src/network.rs
+++ b/src/network.rs
@@ -1,55 +1,72 @@
+use super::{calculate_time_difference, ProbeError, Result};
 use std::collections::HashMap;
-use super::{ProbeError,Result,calculate_time_difference};
 
 pub type Interfaces = HashMap<String, NetworkTraffic>;
 
 /// Measurement of network traffic at a certain time.
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct NetworkTrafficMeasurement {
     pub precise_time_ns: u64,
-    pub interfaces: Interfaces
+    pub interfaces: Interfaces,
 }
 
 impl NetworkTrafficMeasurement {
     /// Calculate the network traffic per minute based on this measurement and a measurement in the
     /// future. It is advisable to make the next measurement roughly a minute from this one for the
     /// most reliable result.
-    pub fn calculate_per_minute(&self, next_measurement: &NetworkTrafficMeasurement) -> Result<NetworkTrafficPerMinute> {
-        let time_difference = calculate_time_difference(self.precise_time_ns, next_measurement.precise_time_ns)?;
+    pub fn calculate_per_minute(
+        &self,
+        next_measurement: &NetworkTrafficMeasurement,
+    ) -> Result<NetworkTrafficPerMinute> {
+        let time_difference =
+            calculate_time_difference(self.precise_time_ns, next_measurement.precise_time_ns)?;
 
         let mut interfaces = Interfaces::new();
 
         for (name, traffic) in self.interfaces.iter() {
             let next_traffic = match next_measurement.interfaces.get(name) {
                 Some(interface) => interface,
-                None => return Err(ProbeError::UnexpectedContent(format!("{} is not present in the next measurement", name)))
+                None => {
+                    return Err(ProbeError::UnexpectedContent(format!(
+                        "{} is not present in the next measurement",
+                        name
+                    )))
+                }
             };
             interfaces.insert(
                 name.to_string(),
                 NetworkTraffic {
-                    received: super::time_adjusted("received", next_traffic.received, traffic.received, time_difference)?,
-                    transmitted: super::time_adjusted("transmitted", next_traffic.transmitted, traffic.transmitted, time_difference)?
-                }
+                    received: super::time_adjusted(
+                        "received",
+                        next_traffic.received,
+                        traffic.received,
+                        time_difference,
+                    )?,
+                    transmitted: super::time_adjusted(
+                        "transmitted",
+                        next_traffic.transmitted,
+                        traffic.transmitted,
+                        time_difference,
+                    )?,
+                },
             );
         }
 
-        Ok(NetworkTrafficPerMinute {
-            interfaces: interfaces
-        })
+        Ok(NetworkTrafficPerMinute { interfaces })
     }
 }
 
 /// Network traffic in bytes.
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct NetworkTraffic {
     pub received: u64,
-    pub transmitted: u64
+    pub transmitted: u64,
 }
 
 /// Network traffic for a certain minute, calculated based on two measurements.
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct NetworkTrafficPerMinute {
-    pub interfaces: Interfaces
+    pub interfaces: Interfaces,
 }
 
 #[cfg(target_os = "linux")]
@@ -59,12 +76,12 @@ pub fn read() -> Result<NetworkTrafficMeasurement> {
 
 #[cfg(target_os = "linux")]
 mod os {
-    use std::io::{self,BufRead};
+    use std::io::{self, BufRead};
     use std::path::Path;
     use time;
 
-    use super::{NetworkTraffic,Interfaces,NetworkTrafficMeasurement};
-    use super::super::{Result,file_to_buf_reader,parse_u64,path_to_string};
+    use super::super::{file_to_buf_reader, parse_u64, path_to_string, Result};
+    use super::{Interfaces, NetworkTraffic, NetworkTrafficMeasurement};
     use error::ProbeError;
 
     #[inline]
@@ -77,9 +94,7 @@ mod os {
         let reader = file_to_buf_reader(path)?;
         let precise_time_ns = time::precise_time_ns();
 
-        let line_result: io::Result<Vec<String>> = reader
-            .lines()
-            .collect();
+        let line_result: io::Result<Vec<String>> = reader.lines().collect();
         let lines = line_result.map_err(|e| ProbeError::IO(e, path_to_string(path)))?;
         let positions = get_positions(lines[1].as_ref())?;
 
@@ -89,63 +104,73 @@ mod os {
             let name = segments[0].trim_matches(':').to_owned();
 
             if segments.len() < positions.transmit_bytes {
-                return Err(ProbeError::UnexpectedContent(
-                    format!(
-                        "Expected at least {} items, had {} for '{}'",
-                        positions.transmit_bytes,
-                        segments.len(),
-                        name
-                    )
-                ))
+                return Err(ProbeError::UnexpectedContent(format!(
+                    "Expected at least {} items, had {} for '{}'",
+                    positions.transmit_bytes,
+                    segments.len(),
+                    name
+                )));
             }
 
             let traffic = NetworkTraffic {
                 received: parse_u64(segments[positions.receive_bytes])?,
-                transmitted: parse_u64(segments[positions.transmit_bytes])?
+                transmitted: parse_u64(segments[positions.transmit_bytes])?,
             };
 
             interfaces.insert(name, traffic);
         }
 
         Ok(NetworkTrafficMeasurement {
-            precise_time_ns: precise_time_ns,
-            interfaces: interfaces
+            precise_time_ns,
+            interfaces,
         })
     }
 
-    #[derive(Debug,PartialEq)]
+    #[derive(Debug, PartialEq)]
     pub struct Positions {
         pub receive_bytes: usize,
-        pub transmit_bytes: usize
+        pub transmit_bytes: usize,
     }
 
     /// Get the positions of the `bytes` field for both the receive and transmit segment
     #[inline]
     pub fn get_positions(header_line: &str) -> Result<Positions> {
-        let groups: Vec<&str> = header_line.split("|").collect();
+        let groups: Vec<&str> = header_line.split('|').collect();
         if groups.len() != 3 {
-            return Err(ProbeError::UnexpectedContent("Incorrect number of segments".to_owned()))
+            return Err(ProbeError::UnexpectedContent(
+                "Incorrect number of segments".to_owned(),
+            ));
         }
         let receive_group: Vec<&str> = groups[1].split_whitespace().collect();
         let transmit_group: Vec<&str> = groups[2].split_whitespace().collect();
 
-        let receive_pos = receive_group.iter().position(|&e| e == "bytes").ok_or(ProbeError::UnexpectedContent("bytes field not found for receive".to_string()))?;
-        let transmit_pos = transmit_group.iter().position(|&e| e == "bytes").ok_or(ProbeError::UnexpectedContent("bytes field not found for transmit".to_string()))?;
+        let receive_pos = receive_group
+            .iter()
+            .position(|&e| e == "bytes")
+            .ok_or_else(|| {
+                ProbeError::UnexpectedContent("bytes field not found for receive".to_string())
+            })?;
+        let transmit_pos = transmit_group
+            .iter()
+            .position(|&e| e == "bytes")
+            .ok_or_else(|| {
+                ProbeError::UnexpectedContent("bytes field not found for transmit".to_string())
+            })?;
 
         // We start with 1 here because the first (name) segment always has one column.
         Ok(Positions {
             receive_bytes: 1 + receive_pos,
-            transmit_bytes: 1 + receive_group.len() + transmit_pos
+            transmit_bytes: 1 + receive_group.len() + transmit_pos,
         })
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use super::super::ProbeError;
+    use super::{Interfaces, NetworkTraffic, NetworkTrafficMeasurement};
     use std::path::Path;
     use time;
-    use super::super::ProbeError;
-    use super::{Interfaces,NetworkTraffic,NetworkTrafficMeasurement};
 
     #[test]
     fn test_read_network() {
@@ -180,7 +205,7 @@ mod tests {
         let path = Path::new("/nonsense");
         match super::os::read_and_parse_network(&path) {
             Err(ProbeError::IO(_, _)) => (),
-            r => panic!("Unexpected result: {:?}", r)
+            r => panic!("Unexpected result: {:?}", r),
         }
     }
 
@@ -189,7 +214,7 @@ mod tests {
         let path = Path::new("fixtures/linux/network/proc_net_dev_incomplete");
         match super::os::read_and_parse_network(&path) {
             Err(ProbeError::UnexpectedContent(_)) => (),
-            r => panic!("Unexpected result: {:?}", r)
+            r => panic!("Unexpected result: {:?}", r),
         }
     }
 
@@ -198,21 +223,21 @@ mod tests {
         let path = Path::new("fixtures/linux/network/proc_net_dev_garbage");
         match super::os::read_and_parse_network(&path) {
             Err(ProbeError::UnexpectedContent(_)) => (),
-            r => panic!("Unexpected result: {:?}", r)
+            r => panic!("Unexpected result: {:?}", r),
         }
     }
 
     #[test]
     fn test_get_positions() {
-      let line = "face |bytes    packets errs drop fifo frame compressed multicast|bytes    packets errs drop fifo colls carrier compressed";
+        let line = "face |bytes    packets errs drop fifo frame compressed multicast|bytes    packets errs drop fifo colls carrier compressed";
 
-      assert_eq!(
-          super::os::Positions {
-            receive_bytes: 1,
-            transmit_bytes: 9
-          },
-          super::os::get_positions(line).unwrap()
-      )
+        assert_eq!(
+            super::os::Positions {
+                receive_bytes: 1,
+                transmit_bytes: 9
+            },
+            super::os::get_positions(line).unwrap()
+        )
     }
 
     #[test]
@@ -221,7 +246,7 @@ mod tests {
 
         match super::os::get_positions(line) {
             Err(ProbeError::UnexpectedContent(_)) => (),
-            r => panic!("Unexpected result: {:?}", r)
+            r => panic!("Unexpected result: {:?}", r),
         }
     }
 
@@ -231,26 +256,50 @@ mod tests {
 
         match super::os::get_positions(line) {
             Err(ProbeError::UnexpectedContent(_)) => (),
-            r => panic!("Unexpected result: {:?}", r)
+            r => panic!("Unexpected result: {:?}", r),
         }
     }
 
     #[test]
     fn test_calculate_per_minute_full_minute() {
         let mut interfaces1 = Interfaces::new();
-        interfaces1.insert("eth0".to_string(), NetworkTraffic{received: 1000, transmitted: 1000});
-        interfaces1.insert("eth1".to_string(), NetworkTraffic{received: 2000, transmitted: 3000});
-        let measurement1 = NetworkTrafficMeasurement{
+        interfaces1.insert(
+            "eth0".to_string(),
+            NetworkTraffic {
+                received: 1000,
+                transmitted: 1000,
+            },
+        );
+        interfaces1.insert(
+            "eth1".to_string(),
+            NetworkTraffic {
+                received: 2000,
+                transmitted: 3000,
+            },
+        );
+        let measurement1 = NetworkTrafficMeasurement {
             precise_time_ns: 60_000_000_000,
-            interfaces: interfaces1
+            interfaces: interfaces1,
         };
 
         let mut interfaces2 = Interfaces::new();
-        interfaces2.insert("eth0".to_string(), NetworkTraffic{received: 2000, transmitted: 2600});
-        interfaces2.insert("eth1".to_string(), NetworkTraffic{received: 3000, transmitted: 4600});
-        let measurement2 = NetworkTrafficMeasurement{
+        interfaces2.insert(
+            "eth0".to_string(),
+            NetworkTraffic {
+                received: 2000,
+                transmitted: 2600,
+            },
+        );
+        interfaces2.insert(
+            "eth1".to_string(),
+            NetworkTraffic {
+                received: 3000,
+                transmitted: 4600,
+            },
+        );
+        let measurement2 = NetworkTrafficMeasurement {
             precise_time_ns: 120_000_000_000,
-            interfaces: interfaces2
+            interfaces: interfaces2,
         };
 
         let per_minute = measurement1.calculate_per_minute(&measurement2).unwrap();
@@ -268,19 +317,43 @@ mod tests {
     #[test]
     fn test_calculate_per_minute_partial_minute() {
         let mut interfaces1 = Interfaces::new();
-        interfaces1.insert("eth0".to_string(), NetworkTraffic{received: 1000, transmitted: 1000});
-        interfaces1.insert("eth1".to_string(), NetworkTraffic{received: 2000, transmitted: 3000});
-        let measurement1 = NetworkTrafficMeasurement{
+        interfaces1.insert(
+            "eth0".to_string(),
+            NetworkTraffic {
+                received: 1000,
+                transmitted: 1000,
+            },
+        );
+        interfaces1.insert(
+            "eth1".to_string(),
+            NetworkTraffic {
+                received: 2000,
+                transmitted: 3000,
+            },
+        );
+        let measurement1 = NetworkTrafficMeasurement {
             precise_time_ns: 60_000_000_000,
-            interfaces: interfaces1
+            interfaces: interfaces1,
         };
 
         let mut interfaces2 = Interfaces::new();
-        interfaces2.insert("eth0".to_string(), NetworkTraffic{received: 2000, transmitted: 2600});
-        interfaces2.insert("eth1".to_string(), NetworkTraffic{received: 3000, transmitted: 4600});
-        let measurement2 = NetworkTrafficMeasurement{
+        interfaces2.insert(
+            "eth0".to_string(),
+            NetworkTraffic {
+                received: 2000,
+                transmitted: 2600,
+            },
+        );
+        interfaces2.insert(
+            "eth1".to_string(),
+            NetworkTraffic {
+                received: 3000,
+                transmitted: 4600,
+            },
+        );
+        let measurement2 = NetworkTrafficMeasurement {
             precise_time_ns: 90_000_000_000,
-            interfaces: interfaces2
+            interfaces: interfaces2,
         };
 
         let per_minute = measurement1.calculate_per_minute(&measurement2).unwrap();
@@ -297,63 +370,87 @@ mod tests {
 
     #[test]
     fn test_calculate_per_minute_wrong_times() {
-        let measurement1 = NetworkTrafficMeasurement{
+        let measurement1 = NetworkTrafficMeasurement {
             precise_time_ns: 90_000_000_000,
-            interfaces: Interfaces::new()
+            interfaces: Interfaces::new(),
         };
 
-        let measurement2 = NetworkTrafficMeasurement{
+        let measurement2 = NetworkTrafficMeasurement {
             precise_time_ns: 60_000_000_000,
-            interfaces: Interfaces::new()
+            interfaces: Interfaces::new(),
         };
 
         match measurement1.calculate_per_minute(&measurement2) {
             Err(ProbeError::InvalidInput(_)) => (),
-            r => panic!("Unexpected result: {:?}", r)
+            r => panic!("Unexpected result: {:?}", r),
         }
     }
 
     #[test]
     fn test_calculate_per_minute_values_lower() {
         let mut interfaces1 = Interfaces::new();
-        interfaces1.insert("eth0".to_string(), NetworkTraffic{received: 2000, transmitted: 3000});
-        let measurement1 = NetworkTrafficMeasurement{
+        interfaces1.insert(
+            "eth0".to_string(),
+            NetworkTraffic {
+                received: 2000,
+                transmitted: 3000,
+            },
+        );
+        let measurement1 = NetworkTrafficMeasurement {
             precise_time_ns: 60_000_000_000,
-            interfaces: interfaces1
+            interfaces: interfaces1,
         };
 
         let mut interfaces2 = Interfaces::new();
-        interfaces2.insert("eth0".to_string(), NetworkTraffic{received: 2000, transmitted: 2600});
-        let measurement2 = NetworkTrafficMeasurement{
+        interfaces2.insert(
+            "eth0".to_string(),
+            NetworkTraffic {
+                received: 2000,
+                transmitted: 2600,
+            },
+        );
+        let measurement2 = NetworkTrafficMeasurement {
             precise_time_ns: 120_000_000_000,
-            interfaces: interfaces2
+            interfaces: interfaces2,
         };
 
         match measurement1.calculate_per_minute(&measurement2) {
             Err(ProbeError::UnexpectedContent(_)) => (),
-            r => panic!("Unexpected result: {:?}", r)
+            r => panic!("Unexpected result: {:?}", r),
         }
     }
 
     #[test]
     fn test_calculate_per_minute_different_interfaces() {
         let mut interfaces1 = Interfaces::new();
-        interfaces1.insert("eth1".to_string(), NetworkTraffic{received: 2000, transmitted: 3000});
-        let measurement1 = NetworkTrafficMeasurement{
+        interfaces1.insert(
+            "eth1".to_string(),
+            NetworkTraffic {
+                received: 2000,
+                transmitted: 3000,
+            },
+        );
+        let measurement1 = NetworkTrafficMeasurement {
             precise_time_ns: 60_000_000_000,
-            interfaces: interfaces1
+            interfaces: interfaces1,
         };
 
         let mut interfaces2 = Interfaces::new();
-        interfaces2.insert("eth0".to_string(), NetworkTraffic{received: 2000, transmitted: 2600});
-        let measurement2 = NetworkTrafficMeasurement{
+        interfaces2.insert(
+            "eth0".to_string(),
+            NetworkTraffic {
+                received: 2000,
+                transmitted: 2600,
+            },
+        );
+        let measurement2 = NetworkTrafficMeasurement {
             precise_time_ns: 120_000_000_000,
-            interfaces: interfaces2
+            interfaces: interfaces2,
         };
 
         match measurement1.calculate_per_minute(&measurement2) {
             Err(ProbeError::UnexpectedContent(_)) => (),
-            r => panic!("Unexpected result: {:?}", r)
+            r => panic!("Unexpected result: {:?}", r),
         }
     }
 }


### PR DESCRIPTION
Go down to zero warnings for Rust 1.42 and adjust formatting to comply with current `rustfmt` default settings. This change does not have much value in its own, but makes this project more accessible for
future community contributions.

Minimum supported Rust version is now 1.36 due to the use of std::mem::MaybeUninit.