### PR TITLE
Convert codebase to Rust 2018 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/appsignal/probes-rs"
 keywords = ["unix", "linux", "probe"]
 license = "MIT"
+edition = "2018"
 
 [dependencies]
 libc = "0.2"

--- a/src/cpu/cgroup.rs
+++ b/src/cpu/cgroup.rs
@@ -64,7 +64,7 @@ mod os {
     use time;
     use super::super::super::{Result,file_to_buf_reader,parse_u64,path_to_string,read_file_value_as_u64,dir_exists};
     use super::{CgroupCpuMeasurement,CgroupCpuStat};
-    use error::ProbeError;
+    use crate::error::ProbeError;
 
     const CPU_SYS_NUMBER_OF_FIELDS: usize = 2;
 
@@ -127,7 +127,7 @@ mod test {
     use super::{CgroupCpuMeasurement,CgroupCpuStat};
     use super::os::read_and_parse_sys_stat;
     use std::path::Path;
-    use error::ProbeError;
+    use crate::error::ProbeError;
 
     #[test]
     fn test_read() {

--- a/src/cpu/proc.rs
+++ b/src/cpu/proc.rs
@@ -96,7 +96,7 @@ mod os {
     use time;
     use super::super::super::{Result,file_to_buf_reader,parse_u64,path_to_string};
     use super::{CpuMeasurement,CpuStat};
-    use error::ProbeError;
+    use crate::error::ProbeError;
 
     #[inline]
     pub fn read() -> Result<CpuMeasurement> {
@@ -155,7 +155,7 @@ mod test {
     use super::{CpuMeasurement,CpuStat,CpuStatPercentages};
     use super::os::read_and_parse_proc_stat;
     use std::path::Path;
-    use error::ProbeError;
+    use crate::error::ProbeError;
 
     #[test]
     fn test_read_cpu() {

--- a/src/disk_stats.rs
+++ b/src/disk_stats.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::path::Path;
 use super::{Result,time_adjusted,calculate_time_difference};
-use error::ProbeError;
+use crate::error::ProbeError;
 
 pub type DiskStats = HashMap<String, DiskStat>;
 
@@ -135,7 +135,7 @@ mod os {
 mod tests {
     use std::collections::HashMap;
     use std::path::Path;
-    use error::ProbeError;
+    use crate::error::ProbeError;
     use super::DiskStatsMeasurement;
     use super::os::read_and_parse_proc_diskstats;
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -32,7 +32,7 @@ impl error::Error for ProbeError {
         }
     }
 
-    fn cause(&self) -> Option<&error::Error> {
+    fn cause(&self) -> Option<&dyn error::Error> {
         match *self {
             ProbeError::IO(ref err, ref _path) => Some(err),
             ProbeError::UnexpectedContent(_) => None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@ use std::io::BufRead;
 use std::path::Path;
 use std::result;
 
-pub use error::ProbeError;
+pub use crate::error::ProbeError;
 
 pub type Result<T> = result::Result<T, error::ProbeError>;
 
@@ -76,7 +76,7 @@ fn dir_exists(path: &Path) -> bool {
 
 #[inline]
 fn read_file_value_as_u64(path: &Path) -> Result<u64> {
-    let mut reader = try!(file_to_buf_reader(path));
+    let mut reader = file_to_buf_reader(path)?;
     let mut line = String::new();
     reader.read_line(&mut line).map_err(|e| ProbeError::IO(e, path_to_string(path)))?;
     parse_u64(&line.trim())
@@ -84,7 +84,7 @@ fn read_file_value_as_u64(path: &Path) -> Result<u64> {
 
 #[cfg(test)]
 mod tests {
-    use error::ProbeError;
+    use crate::error::ProbeError;
 
     #[test]
     fn test_calculate_time_difference() {

--- a/src/network.rs
+++ b/src/network.rs
@@ -65,7 +65,7 @@ mod os {
 
     use super::{NetworkTraffic,Interfaces,NetworkTrafficMeasurement};
     use super::super::{Result,file_to_buf_reader,parse_u64,path_to_string};
-    use error::ProbeError;
+    use crate::error::ProbeError;
 
     #[inline]
     pub fn read() -> Result<NetworkTrafficMeasurement> {

--- a/src/process_memory.rs
+++ b/src/process_memory.rs
@@ -63,7 +63,7 @@ mod os {
 
     #[inline]
     pub fn max_rss() -> u64 {
-        let mut rusage: libc::rusage = unsafe { mem::uninitialized() };
+        let mut rusage: libc::rusage = unsafe { mem::MaybeUninit::uninit().assume_init() };
         unsafe { libc::getrusage(libc::RUSAGE_SELF, &mut rusage) };
         rusage.ru_maxrss as u64
     }


### PR DESCRIPTION
Closes #45. Changes tested (and made) on Ubuntu 20.04.