### PR TITLE
Swap precise_time_ns for stdlib implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,8 @@ name = "probes"
 version = "0.3.0"
 authors = ["Thijs Cadier <thijs@appsignal.com>",
            "Robert Beekman <robert@appsignal.com>",
-           "Timon Vonk <mail@timonv.nl>"]
+           "Timon Vonk <mail@timonv.nl>",
+           "Adam Yeats <adam@appsignal.com>"]
 description = "Library to read out system stats from a machine running Unix"
 readme = "README.md"
 repository = "https://github.com/appsignal/probes-rs/"
@@ -13,4 +14,3 @@ edition = "2018"
 
 [dependencies]
 libc = "0.2"
-time = "0.1.34"

--- a/src/cpu/cgroup.rs
+++ b/src/cpu/cgroup.rs
@@ -79,7 +79,8 @@ pub fn read() -> Result<CgroupCpuMeasurement> {
 #[cfg(target_os = "linux")]
 mod os {
     use super::super::super::{
-        dir_exists, file_to_buf_reader, parse_u64, path_to_string, read_file_value_as_u64, Result,
+        dir_exists, file_to_buf_reader, parse_u64, path_to_string, precise_time_ns,
+        read_file_value_as_u64, Result,
     };
     use super::{CgroupCpuMeasurement, CgroupCpuStat};
     use crate::error::ProbeError;
@@ -102,7 +103,8 @@ mod os {
     }
 
     pub fn read_and_parse_sys_stat(path: &Path) -> Result<CgroupCpuMeasurement> {
-        let time = time::precise_time_ns();
+        let time = precise_time_ns();
+
         let reader = file_to_buf_reader(&path.join("cpuacct.stat"))?;
         let total_usage = read_file_value_as_u64(&path.join("cpuacct.usage"))?;
 

--- a/src/cpu/proc.rs
+++ b/src/cpu/proc.rs
@@ -147,7 +147,7 @@ pub fn read() -> Result<CpuMeasurement> {
 
 #[cfg(target_os = "linux")]
 mod os {
-    use super::super::super::{file_to_buf_reader, parse_u64, path_to_string, Result};
+    use super::super::super::{file_to_buf_reader, parse_u64, path_to_string, precise_time_ns, Result};
     use super::{CpuMeasurement, CpuStat};
     use crate::error::ProbeError;
     use std::io::BufRead;
@@ -162,7 +162,8 @@ mod os {
         let mut line = String::new();
         // columns: user nice system idle iowait irq softirq
         let mut reader = file_to_buf_reader(path)?;
-        let time = time::precise_time_ns();
+        let time = precise_time_ns();
+
         reader
             .read_line(&mut line)
             .map_err(|e| ProbeError::IO(e, path_to_string(path)))?;

--- a/src/disk_stats.rs
+++ b/src/disk_stats.rs
@@ -148,19 +148,20 @@ pub fn read() -> Result<DiskStatsMeasurement> {
 
 #[cfg(target_os = "linux")]
 mod os {
-    use super::super::{file_to_buf_reader, parse_u64, path_to_string, ProbeError, Result};
+    use super::super::{
+        file_to_buf_reader, parse_u64, path_to_string, precise_time_ns, ProbeError, Result,
+    };
     use super::{DiskStat, DiskStatsMeasurement};
     use std::collections::HashMap;
     use std::io::BufRead;
     use std::path::Path;
-    use time;
 
     #[inline]
     pub fn read_and_parse_proc_diskstats(path: &Path) -> Result<DiskStatsMeasurement> {
         let reader = file_to_buf_reader(path)?;
 
         let mut out = DiskStatsMeasurement {
-            precise_time_ns: time::precise_time_ns(),
+            precise_time_ns: precise_time_ns(),
             stats: HashMap::new(),
         };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 extern crate libc;
-extern crate time;
 
 pub mod cpu;
 pub mod disk_stats;
@@ -16,6 +15,7 @@ use std::io::BufRead;
 use std::io::Read;
 use std::path::Path;
 use std::result;
+use std::time::SystemTime;
 
 pub use crate::error::ProbeError;
 
@@ -94,6 +94,14 @@ fn read_file_value_as_u64(path: &Path) -> Result<u64> {
         .read_line(&mut line)
         .map_err(|e| ProbeError::IO(e, path_to_string(path)))?;
     parse_u64(&line.trim())
+}
+
+#[inline]
+fn precise_time_ns() -> u64 {
+    return SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos() as u64;
 }
 
 #[cfg(test)]

--- a/src/network.rs
+++ b/src/network.rs
@@ -79,7 +79,7 @@ mod os {
     use std::io::{self, BufRead};
     use std::path::Path;
 
-    use super::super::{file_to_buf_reader, parse_u64, path_to_string, Result};
+    use super::super::{file_to_buf_reader, parse_u64, path_to_string, precise_time_ns, Result};
     use super::{Interfaces, NetworkTraffic, NetworkTrafficMeasurement};
     use crate::error::ProbeError;
 
@@ -91,7 +91,8 @@ mod os {
     #[inline]
     pub fn read_and_parse_network(path: &Path) -> Result<NetworkTrafficMeasurement> {
         let reader = file_to_buf_reader(path)?;
-        let precise_time_ns = time::precise_time_ns();
+
+        let precise_time_ns = precise_time_ns();
 
         let line_result: io::Result<Vec<String>> = reader.lines().collect();
         let lines = line_result.map_err(|e| ProbeError::IO(e, path_to_string(path)))?;
@@ -167,7 +168,7 @@ mod os {
 #[cfg(test)]
 #[cfg(target_os = "linux")]
 mod tests {
-    use super::super::ProbeError;
+    use super::super::{precise_time_ns, ProbeError};
     use super::{Interfaces, NetworkTraffic, NetworkTrafficMeasurement};
     use std::path::Path;
 
@@ -181,7 +182,8 @@ mod tests {
     fn test_read_and_parse_network() {
         let path = Path::new("fixtures/linux/network/proc_net_dev");
         let measurement = super::os::read_and_parse_network(&path).unwrap();
-        assert!(measurement.precise_time_ns < time::precise_time_ns());
+
+        assert!(measurement.precise_time_ns < precise_time_ns());
 
         let interfaces = measurement.interfaces;
         assert_eq!(3, interfaces.len());


### PR DESCRIPTION
This PR removes the deprecated `time` crate and uses a new `precise_time_ns` function that uses `std::time`. Note that `std::time` is a Rust 1.8.0 feature.