### PR TITLE
Add os::read_inodes method to read inodes usage

### DIFF
--- a/fixtures/linux/disk_usage/df_garbage
+++ b/fixtures/linux/disk_usage/df_garbage
@@ -1,2 +1,2 @@
 Filesystem           1K-blocks      Used Available Use% Mounted on
-Ph'nglui mglw'nafh Cthulhu R'lyeh wgah'nagl fhtagn
+Ph'nglui mglw'nafhuCthulhu R'lyehjwgah'nagl fhtagn

--- a/fixtures/linux/disk_usage/df_i
+++ b/fixtures/linux/disk_usage/df_i
@@ -1,0 +1,4 @@
+Filesystem         Inodes   IUsed      IFree IUse% Mounted on
+overlay           2097152  122591    1974561    6% /
+tmpfs              254863      16     254847    1% /dev
+tmpfs              254863      15     254848    1% /sys/fs/cgroup


### PR DESCRIPTION
Adds `crate::os:read_inodes()` method to read the output of `df -i` into a vector of `DiskInodeUsage`s. 

A quick word on `fixtures/linux/disk_usage/df_garbage`: I changed the fixture, as `parse_percentage_segment` (containing the `Err` that would make the test pass normally) is not called by `parse_df_output` anymore; it's called a level up instead.

Closes #43.