### PR TITLE
Add shmem Memory struct function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.4.3
+
+- Add shared memory metric function `Memory.shmem()`.
+
 ## 0.4.2
 
 - Support shared memory metric. For containers only cgroups v1 is supported.

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -44,6 +44,11 @@ impl Memory {
     pub fn swap_used(&self) -> u64 {
         self.swap_used
     }
+
+    /// Total amount of shared memory
+    pub fn shmem(&self) -> u64 {
+        self.shmem
+    }
 }
 
 /// Read the current memory status of the system.


### PR DESCRIPTION
I didn't realize we don't make the fields public for the Memory struct. Add a function to read from the struct. That follows the style that already exists.