### PR TITLE
Add CPU total usage percentage for /proc based

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.1
+
+- Add support for CPU total usage for `/proc` based systems (VMs).
+
 ## 0.5.0
 
 - Add support for cgroups v2 in CPU and memory metrics

--- a/src/cpu/proc.rs
+++ b/src/cpu/proc.rs
@@ -106,6 +106,7 @@ impl CpuStat {
     /// Calculate the weight of the various components in percentages
     pub fn in_percentages(&self) -> CpuStatPercentages {
         CpuStatPercentages {
+            total_usage: self.percentage_of_total(self.total - self.idle),
             user: self.percentage_of_total(self.user),
             nice: self.percentage_of_total(self.nice),
             system: self.percentage_of_total(self.system),
@@ -127,6 +128,7 @@ impl CpuStat {
 /// Cpu stats converted to percentages
 #[derive(Debug, PartialEq)]
 pub struct CpuStatPercentages {
+    pub total_usage: f32,
     pub user: f32,
     pub nice: f32,
     pub system: f32,
@@ -494,6 +496,7 @@ mod test {
         };
 
         let expected = CpuStatPercentages {
+            total_usage: 90.0,
             user: 45.0,
             nice: 7.0,
             system: 10.0,
@@ -526,6 +529,7 @@ mod test {
         };
 
         let expected = CpuStatPercentages {
+            total_usage: 90.0,
             user: 44.5,
             nice: 6.5,
             system: 10.0,


### PR DESCRIPTION
Track the total usage in percentage by subtracting the idle time from the total time.

This is based on this post, but then the reverse as we don't want the idle time, but the busy time.

https://www.baeldung.com/linux/get-cpu-usage#2-getting-cpu-usage-using-procstat

Part of https://github.com/appsignal/probes-rs/issues/64