### PR TITLE
Fix rss test failure on some Semaphore builds

### DIFF
--- a/src/process_memory.rs
+++ b/src/process_memory.rs
@@ -136,8 +136,8 @@ mod tests {
 
     #[test]
     fn test_max_rss() {
-        // See if it's a sort of sane value, between 1 and 250 mb
+        // See if it's a sort of sane value, between 1 and 700 mb
         assert!(super::max_rss() > 1_000);
-        assert!(super::max_rss() < 250_000);
+        assert!(super::max_rss() < 700_000);
     }
 }


### PR DESCRIPTION
Fix rss test failure on some Semaphore builds

Edit: The OS images that use cgroups v2 consume way more memory than we expect in our tests.,