### PR TITLE
Support Alpine Linux disk usage reporting using df

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Support disk usage reporting (using `df`) on Alpine Linux.
+
 ## 0.5.2
 
 - Normalize CPU usage percentages for cgroups v2 systems

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Support disk usage reporting (using `df`) on Alpine Linux.
+- When a disk mountpoint has no inodes usage percentage, skip the mountpoint, and report the inodes information successfully for the inodes that do have an inodes usage percentage.
 
 ## 0.5.2
 

--- a/fixtures/linux/disk_usage/df_i_dash_percentage
+++ b/fixtures/linux/disk_usage/df_i_dash_percentage
@@ -1,0 +1,3 @@
+Filesystem         Inodes   IUsed      IFree IUse% Mounted on
+overlay           2097152  122591    1974561    6% /
+tmpfs              254863      16     254847     - /dev


### PR DESCRIPTION
On Ubuntu, `df` lists all disk by default. Using the `-l/--local` flag, it only lists the local disks, as per the help output:

```
-l, --local           limit listing to local file systems
```

On Alpine Linux the `-l/--local` flag does not exist. Instead it has a `-a` flag to do the opposite:

```
-a	Show all filesystems
```

Try running `df` without any flags when `df --local` doesn't work. (Use the full `--local` flag name so it's easier to figure out what it's doing when reading the code.)
This way we can parse the output on Alpine Linux.

Closes #70