### PR TITLE
Omit inodes for mountpoints with a dash percentage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 - Support disk usage reporting (using `df`) on Alpine Linux.
-- Don't report inodes for mountpoints that report no usage percentage.
+- When a disk mountpoint has no inodes usage percentage, skip the mountpoint, and report the inodes information successfully for the inodes that do have an inodes usage percentage.
 
 ## 0.5.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Support disk usage reporting (using `df`) on Alpine Linux.
+- Don't report inodes for mountpoints that report no usage percentage.
 
 ## 0.5.2
 

--- a/fixtures/linux/disk_usage/df_i_dash_percentage
+++ b/fixtures/linux/disk_usage/df_i_dash_percentage
@@ -1,0 +1,3 @@
+Filesystem         Inodes   IUsed      IFree IUse% Mounted on
+overlay           2097152  122591    1974561    6% /
+tmpfs              254863      16     254847     - /dev


### PR DESCRIPTION
We had a report from someone with `df -i` output that reported a dash (-) for the inodes used percentage for a mountpoint.

I can only reproduce this with a `df -i --all` call, but it's good to safeguard against the percentage being a dash. When no percentage is found, skip the mountpoint entirely.

We could also make the `iused_percentage` field an Option, but this is a smaller change, fixing a possible error. This won't change the public API. Our agent only uses the percentage, so making it an Option wouldn't make a difference for our metrics reporting.

Closes #68