### PR TITLE
Check df exit code to determine command failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.4
+
+- Fix disk usage returning a Vec with no entries on Alpine Linux when the `df --local` command fails.
+
 ## 0.5.3
 
 - Support disk usage reporting (using `df`) on Alpine Linux.

--- a/src/disk_usage.rs
+++ b/src/disk_usage.rs
@@ -182,10 +182,19 @@ mod os {
 
         let output = cmd
             .output()
-            .map_err(|e| ProbeError::IO(e, format!("df {}", options.unwrap_or(&[]).join(" "))))?
-            .stdout;
+            .map_err(|e| ProbeError::IO(e, format!("df {}", options.unwrap_or(&[]).join(" "))))?;
+        let stdout = output.stdout;
+        let status = output.status;
 
-        Ok(String::from_utf8_lossy(&output).to_string())
+        if status.success() {
+            Ok(String::from_utf8_lossy(&stdout).to_string())
+        } else {
+            Err(ProbeError::StatusFailure(format!(
+                "Command `df` returned failure exit code '{:?}': df {}",
+                status.code(),
+                options.unwrap_or(&[]).join(" ")
+            )))
+        }
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -11,6 +11,8 @@ pub enum ProbeError {
     UnexpectedContent(String),
     /// Input into a calculation function is invalid
     InvalidInput(String),
+    /// Command failed
+    StatusFailure(String),
 }
 
 impl fmt::Display for ProbeError {
@@ -19,6 +21,7 @@ impl fmt::Display for ProbeError {
             ProbeError::IO(ref err, ref path) => write!(f, "{} for {}", err, path),
             ProbeError::UnexpectedContent(ref err) => write!(f, "{}", err),
             ProbeError::InvalidInput(ref err) => write!(f, "{}", err),
+            ProbeError::StatusFailure(ref err) => write!(f, "{}", err),
         }
     }
 }
@@ -30,6 +33,7 @@ impl error::Error for ProbeError {
             ProbeError::IO(ref err, ref _path) => err.description(),
             ProbeError::UnexpectedContent(ref err) => err,
             ProbeError::InvalidInput(ref err) => err,
+            ProbeError::StatusFailure(ref err) => err,
         }
     }
 
@@ -38,6 +42,7 @@ impl error::Error for ProbeError {
             ProbeError::IO(ref err, ref _path) => Some(err),
             ProbeError::UnexpectedContent(_) => None,
             ProbeError::InvalidInput(_) => None,
+            ProbeError::StatusFailure(_) => None,
         }
     }
 }


### PR DESCRIPTION
When running a command with `Command`, we need to check the exit code using the `status` field on the `Output` struct.

If it doesn't return an error reading the output, it doesn't mean the command did _not_ fail.

Thanks to @unflxw for spotting this in https://github.com/appsignal/probes-rs/issues/75#issuecomment-1883013609

Fixes #75