### PR TITLE
Update build machine for CI

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -3,7 +3,7 @@ name: probes-rs
 agent:
   machine:
     type: e1-standard-2
-    os_image: ubuntu1804
+    os_image: ubuntu2004
 global_job_config:
   prologue:
     commands:


### PR DESCRIPTION
Ubuntu 18 is in a "brownout phase" and won't run any builds anymore at certain times.

[skip changeset]
[skip review]