### PR TITLE
Add CPU share parameter

### DIFF
--- a/src/cpu/cgroup.rs
+++ b/src/cpu/cgroup.rs
@@ -74,14 +74,14 @@ pub struct CgroupCpuStatPercentages {
 
 /// Read the current CPU stats of the container.
 #[cfg(target_os = "linux")]
-pub fn read() -> Result<CgroupCpuMeasurement> {
+pub fn read(cpu_count: Option<f64>) -> Result<CgroupCpuMeasurement> {
     use super::cgroup_v1::read_and_parse_v1_sys_stat;
     use super::cgroup_v2::read_and_parse_v2_sys_stat;
 
     let v2_sys_fs_file = Path::new("/sys/fs/cgroup/cpu.stat");
     if v2_sys_fs_file.exists() {
         let v2_sys_fs_cpu_max_file = Path::new("/sys/fs/cgroup/cpu.max");
-        return read_and_parse_v2_sys_stat(&v2_sys_fs_file, v2_sys_fs_cpu_max_file);
+        return read_and_parse_v2_sys_stat(&v2_sys_fs_file, v2_sys_fs_cpu_max_file, cpu_count);
     }
 
     let v1_sys_fs_dir = Path::new("/sys/fs/cgroup/cpuacct/");
@@ -90,6 +90,7 @@ pub fn read() -> Result<CgroupCpuMeasurement> {
             &v1_sys_fs_dir,
             &Path::new("/sys/fs/cgroup/cpu/cpu.cfs_period_us"),
             &Path::new("/sys/fs/cgroup/cpu/cpu.cfs_quota_us"),
+            cpu_count,
         );
     }
 
@@ -108,7 +109,8 @@ mod test {
 
     #[test]
     fn test_read() {
-        assert!(super::read().is_ok());
+        assert!(super::read(None).is_ok());
+        assert!(super::read(Some(0.5)).is_ok());
     }
 
     #[test]

--- a/src/cpu/cgroup_v1.rs
+++ b/src/cpu/cgroup_v1.rs
@@ -14,21 +14,23 @@ pub fn read_and_parse_v1_sys_stat(
     path: &Path,
     cpu_period_path: &Path,
     cpu_quota_path: &Path,
+    mut cpu_count: Option<f64>,
 ) -> Result<CgroupCpuMeasurement> {
     let time = precise_time_ns();
 
-    // If the CPU period and quota files exist, we can use it to calculate the number of CPUs in
-    // the cgroup.
-    let mut cpu_count = 0.0;
-    if cpu_period_path.exists() && cpu_quota_path.exists() {
-        let cpu_period = parse_u64(file_to_string(&cpu_period_path)?.trim())? as f64;
-        let cpu_quota_raw = file_to_string(&cpu_quota_path)?.trim().to_string();
-        // The value `-1` means no quota is set and we can't calculate the number of CPUs present.
-        if cpu_quota_raw != "-1" {
-            let cpu_quota = parse_u64(&cpu_quota_raw)? as f64;
-            cpu_count = cpu_quota / cpu_period;
+    if cpu_count.is_none() {
+        // If the CPU period and quota files exist, we can use it to calculate the number of CPUs in
+        // the cgroup.
+        if cpu_period_path.exists() && cpu_quota_path.exists() {
+            let cpu_period = parse_u64(file_to_string(&cpu_period_path)?.trim())? as f64;
+            let cpu_quota_raw = file_to_string(&cpu_quota_path)?.trim().to_string();
+            // The value `-1` means no quota is set and we can't calculate the number of CPUs present.
+            if cpu_quota_raw != "-1" {
+                let cpu_quota = parse_u64(&cpu_quota_raw)? as f64;
+                cpu_count = Some(cpu_quota / cpu_period);
+            }
         }
-    }
+    };
 
     let reader = file_to_buf_reader(&path.join("cpuacct.stat"))?;
     let total_usage = read_file_value_as_u64(&path.join("cpuacct.usage"))?;
@@ -38,8 +40,10 @@ pub fn read_and_parse_v1_sys_stat(
         user: 0,
         system: 0,
     };
-    if cpu_count > 0.0 {
-        cpu.total_usage = (cpu.total_usage as f64 / cpu_count).round() as u64;
+    if let Some(cpu_count) = cpu_count {
+        if cpu_count > 0.0 {
+            cpu.total_usage = (cpu.total_usage as f64 / cpu_count).round() as u64;
+        }
     }
 
     let mut fields_encountered = 0;
@@ -89,6 +93,7 @@ mod test {
             &Path::new("fixtures/linux/sys/fs/cgroup_v1/cpuacct_1/"),
             &Path::new("fixtures/linux/sys/fs/cgroup_v1/cpu_quota/does_not_exist"),
             &Path::new("fixtures/linux/sys/fs/cgroup_v1/cpu_quota/does_not_exist"),
+            None,
         )
         .unwrap();
         let cpu = measurement.stat;
@@ -103,6 +108,7 @@ mod test {
             &Path::new("fixtures/linux/sys/fs/cgroup_v1/cpuacct_1/"),
             &Path::new("fixtures/linux/sys/fs/cgroup_v1/cpu_quota/cpu.cfs_period_us"),
             &Path::new("fixtures/linux/sys/fs/cgroup_v1/cpu_quota/cpu.cfs_quota_us.one_cpu"),
+            None,
         )
         .unwrap();
         let cpu = measurement.stat;
@@ -117,6 +123,7 @@ mod test {
             &Path::new("fixtures/linux/sys/fs/cgroup_v1/cpuacct_1/"),
             &Path::new("fixtures/linux/sys/fs/cgroup_v1/cpu_quota/cpu.cfs_period_us"),
             &Path::new("fixtures/linux/sys/fs/cgroup_v1/cpu_quota/cpu.cfs_quota_us.two_cpu"),
+            None,
         )
         .unwrap();
         let cpu = measurement.stat;
@@ -131,6 +138,7 @@ mod test {
             &Path::new("fixtures/linux/sys/fs/cgroup_v1/cpuacct_1/"),
             &Path::new("fixtures/linux/sys/fs/cgroup_v1/cpu_quota/cpu.cfs_period_us"),
             &Path::new("fixtures/linux/sys/fs/cgroup_v1/cpu_quota/cpu.cfs_quota_us.half_cpu"),
+            None,
         )
         .unwrap();
         let cpu = measurement.stat;
@@ -145,6 +153,7 @@ mod test {
             &Path::new("fixtures/linux/sys/fs/cgroup_v1/cpuacct_1/"),
             &Path::new("fixtures/linux/sys/fs/cgroup_v1/cpu_quota/cpu.cfs_period_us"),
             &Path::new("fixtures/linux/sys/fs/cgroup_v1/cpu_quota/cpu.cfs_quota_us.minus_one"),
+            None,
         )
         .unwrap();
         let cpu = measurement.stat;
@@ -155,11 +164,57 @@ mod test {
     }
 
     #[test]
+    fn test_read_v1_sys_measurement_one_cpu_count() {
+        let measurement = read_and_parse_v1_sys_stat(
+            &Path::new("fixtures/linux/sys/fs/cgroup_v1/cpuacct_1/"),
+            &Path::new("fixtures/linux/sys/fs/cgroup_v1/cpu_quota/cpu.cfs_period_us"),
+            &Path::new("fixtures/linux/sys/fs/cgroup_v1/cpu_quota/cpu.cfs_quota_us.minus_one"),
+            Some(1.0),
+        )
+        .unwrap();
+        let cpu = measurement.stat;
+        assert_eq!(cpu.total_usage, 152657213021);
+        assert_eq!(cpu.user, 149340000000);
+        assert_eq!(cpu.system, 980000000);
+    }
+
+    #[test]
+    fn test_read_v1_sys_measurement_half_cpu_count() {
+        let measurement = read_and_parse_v1_sys_stat(
+            &Path::new("fixtures/linux/sys/fs/cgroup_v1/cpuacct_1/"),
+            &Path::new("fixtures/linux/sys/fs/cgroup_v1/cpu_quota/cpu.cfs_period_us"),
+            &Path::new("fixtures/linux/sys/fs/cgroup_v1/cpu_quota/cpu.cfs_quota_us.minus_one"),
+            Some(0.5),
+        )
+        .unwrap();
+        let cpu = measurement.stat;
+        assert_eq!(cpu.total_usage, 305314426042);
+        assert_eq!(cpu.user, 149340000000);
+        assert_eq!(cpu.system, 980000000);
+    }
+
+    #[test]
+    fn test_read_v1_sys_measurement_two_cpu_count() {
+        let measurement = read_and_parse_v1_sys_stat(
+            &Path::new("fixtures/linux/sys/fs/cgroup_v1/cpuacct_1/"),
+            &Path::new("fixtures/linux/sys/fs/cgroup_v1/cpu_quota/cpu.cfs_period_us"),
+            &Path::new("fixtures/linux/sys/fs/cgroup_v1/cpu_quota/cpu.cfs_quota_us.minus_one"),
+            Some(2.0),
+        )
+        .unwrap();
+        let cpu = measurement.stat;
+        assert_eq!(cpu.total_usage, 76328606511);
+        assert_eq!(cpu.user, 149340000000);
+        assert_eq!(cpu.system, 980000000);
+    }
+
+    #[test]
     fn test_read_v1_sys_wrong_path() {
         match read_and_parse_v1_sys_stat(
             &Path::new("bananas"),
             &Path::new("fixtures/linux/sys/fs/cgroup_v1/cpu_quota/does_not_exist"),
             &Path::new("fixtures/linux/sys/fs/cgroup_v1/cpu_quota/does_not_exist"),
+            None,
         ) {
             Err(ProbeError::IO(_, _)) => (),
             r => panic!("Unexpected result: {:?}", r),
@@ -172,6 +227,7 @@ mod test {
             &Path::new("fixtures/linux/sys/fs/cgroup_v1/cpuacct_incomplete/"),
             &Path::new("fixtures/linux/sys/fs/cgroup_v1/cpu_quota/does_not_exist"),
             &Path::new("fixtures/linux/sys/fs/cgroup_v1/cpu_quota/does_not_exist"),
+            None,
         ) {
             Err(ProbeError::UnexpectedContent(_)) => (),
             r => panic!("Unexpected result: {:?}", r),
@@ -184,6 +240,7 @@ mod test {
             &Path::new("fixtures/linux/sys/fs/cgroup_v1/cpuacct_garbage/"),
             &Path::new("fixtures/linux/sys/fs/cgroup_v1/cpu_quota/does_not_exist"),
             &Path::new("fixtures/linux/sys/fs/cgroup_v1/cpu_quota/does_not_exist"),
+            None,
         ) {
             Err(ProbeError::UnexpectedContent(_)) => (),
             r => panic!("Unexpected result: {:?}", r),
@@ -196,6 +253,7 @@ mod test {
             &Path::new("fixtures/linux/sys/fs/cgroup_v1/cpuacct_1/"),
             &Path::new("fixtures/linux/sys/fs/cgroup_v1/cpu_quota/does_not_exist"),
             &Path::new("fixtures/linux/sys/fs/cgroup_v1/cpu_quota/does_not_exist"),
+            None,
         )
         .unwrap();
         measurement1.precise_time_ns = 375953965125920;
@@ -203,6 +261,7 @@ mod test {
             &Path::new("fixtures/linux/sys/fs/cgroup_v1/cpuacct_2/"),
             &Path::new("fixtures/linux/sys/fs/cgroup_v1/cpu_quota/does_not_exist"),
             &Path::new("fixtures/linux/sys/fs/cgroup_v1/cpu_quota/does_not_exist"),
+            None,
         )
         .unwrap();
         measurement2.precise_time_ns = 376013815302920;
@@ -228,6 +287,7 @@ mod test {
             &Path::new("fixtures/linux/sys/fs/cgroup_v1/cpuacct_1/"),
             &Path::new("fixtures/linux/sys/fs/cgroup_v1/cpu_quota/cpu.cfs_period_us"),
             &Path::new("fixtures/linux/sys/fs/cgroup_v1/cpu_quota/cpu.cfs_quota_us.two_cpu"),
+            None,
         )
         .unwrap();
         measurement1.precise_time_ns = 375953965125920;
@@ -235,6 +295,7 @@ mod test {
             &Path::new("fixtures/linux/sys/fs/cgroup_v1/cpuacct_2/"),
             &Path::new("fixtures/linux/sys/fs/cgroup_v1/cpu_quota/cpu.cfs_period_us"),
             &Path::new("fixtures/linux/sys/fs/cgroup_v1/cpu_quota/cpu.cfs_quota_us.two_cpu"),
+            None,
         )
         .unwrap();
         measurement2.precise_time_ns = 376013815302920;
@@ -260,6 +321,7 @@ mod test {
             &Path::new("fixtures/linux/sys/fs/cgroup_v1/cpuacct_1/"),
             &Path::new("fixtures/linux/sys/fs/cgroup_v1/cpu_quota/cpu.cfs_period_us"),
             &Path::new("fixtures/linux/sys/fs/cgroup_v1/cpu_quota/cpu.cfs_quota_us.half_cpu"),
+            None,
         )
         .unwrap();
         measurement1.precise_time_ns = 375953965125920;
@@ -267,6 +329,7 @@ mod test {
             &Path::new("fixtures/linux/sys/fs/cgroup_v1/cpuacct_2/"),
             &Path::new("fixtures/linux/sys/fs/cgroup_v1/cpu_quota/cpu.cfs_period_us"),
             &Path::new("fixtures/linux/sys/fs/cgroup_v1/cpu_quota/cpu.cfs_quota_us.half_cpu"),
+            None,
         )
         .unwrap();
         measurement2.precise_time_ns = 376013815302920;

--- a/src/cpu/cgroup_v2.rs
+++ b/src/cpu/cgroup_v2.rs
@@ -10,21 +10,23 @@ const CPU_SYS_V2_NUMBER_OF_FIELDS: usize = 3;
 pub fn read_and_parse_v2_sys_stat(
     path: &Path,
     cpu_max_path: &Path,
+    mut cpu_count: Option<f64>,
 ) -> Result<CgroupCpuMeasurement> {
     // If the cpu.max file exists, we can use it to calculate the number of CPUs
     // in the cgroup. It's also required that the first value is not set to "max",
     // otherwise we can't calculate the number of CPUs.
-    let mut cpu_count = 0.0;
-    if cpu_max_path.exists() {
-        let reader = file_to_buf_reader(&cpu_max_path)?;
-        let mut lines = reader.lines();
-        if let Some(Ok(line)) = lines.next() {
-            let segments: Vec<&str> = line.split_whitespace().collect();
-            let max = segments[0];
+    if cpu_count.is_none() {
+        if cpu_max_path.exists() {
+            let reader = file_to_buf_reader(&cpu_max_path)?;
+            let mut lines = reader.lines();
+            if let Some(Ok(line)) = lines.next() {
+                let segments: Vec<&str> = line.split_whitespace().collect();
+                let max = segments[0];
 
-            if max != "max" {
-                let period = parse_u64(&segments[1])? as f64;
-                cpu_count = parse_u64(&max)? as f64 / period;
+                if max != "max" {
+                    let period = parse_u64(&segments[1])? as f64;
+                    cpu_count = Some(parse_u64(&max)? as f64 / period);
+                }
             }
         }
     }
@@ -47,8 +49,10 @@ pub fn read_and_parse_v2_sys_stat(
             "usage_usec" => {
                 cpu.total_usage = value * 1_000;
 
-                if cpu_count > 0.0 {
-                    cpu.total_usage = (cpu.total_usage as f64 / cpu_count).round() as u64;
+                if let Some(cpu_count) = cpu_count {
+                    if cpu_count > 0.0 {
+                        cpu.total_usage = (cpu.total_usage as f64 / cpu_count).round() as u64;
+                    }
                 }
                 1
             }
@@ -85,13 +89,14 @@ pub fn read_and_parse_v2_sys_stat(
 mod test {
     use super::read_and_parse_v2_sys_stat;
     use crate::error::ProbeError;
-    use std::path::Path;
+    use std::{option::Option::None, path::Path};
 
     #[test]
     fn test_read_v2_sys_measurement_default_cpu_max() {
         let measurement = read_and_parse_v2_sys_stat(
             &Path::new("fixtures/linux/sys/fs/cgroup_v2/cpu.stat_1"),
             &Path::new("fixtures/linux/sys/fs/cgroup_v2/cpu.max_default"),
+            None,
         )
         .unwrap();
         let cpu = measurement.stat;
@@ -105,6 +110,7 @@ mod test {
         let measurement = read_and_parse_v2_sys_stat(
             &Path::new("fixtures/linux/sys/fs/cgroup_v2/cpu.stat_1"),
             &Path::new("fixtures/linux/sys/fs/cgroup_v2/cpu.max_2_cpus"),
+            None,
         )
         .unwrap();
         let cpu = measurement.stat;
@@ -118,6 +124,49 @@ mod test {
         let measurement = read_and_parse_v2_sys_stat(
             &Path::new("fixtures/linux/sys/fs/cgroup_v2/cpu.stat_1"),
             &Path::new("fixtures/linux/sys/fs/cgroup_v2/cpu.max_half"),
+            None,
+        )
+        .unwrap();
+        let cpu = measurement.stat;
+        assert_eq!(cpu.total_usage, 342924000);
+        assert_eq!(cpu.user, 53792000);
+        assert_eq!(cpu.system, 117670000);
+    }
+
+    #[test]
+    fn test_read_v2_sys_one_cpu_count() {
+        let measurement = read_and_parse_v2_sys_stat(
+            &Path::new("fixtures/linux/sys/fs/cgroup_v2/cpu.stat_1"),
+            &Path::new("fixtures/linux/sys/fs/cgroup_v2/cpu.max_garbage"),
+            Some(1.0),
+        )
+        .unwrap();
+        let cpu = measurement.stat;
+        assert_eq!(cpu.total_usage, 171462000);
+        assert_eq!(cpu.user, 53792000);
+        assert_eq!(cpu.system, 117670000);
+    }
+
+    #[test]
+    fn test_read_v2_sys_measurement_two_cpu_count() {
+        let measurement = read_and_parse_v2_sys_stat(
+            &Path::new("fixtures/linux/sys/fs/cgroup_v2/cpu.stat_1"),
+            &Path::new("fixtures/linux/sys/fs/cgroup_v2/cpu.max_garbage"),
+            Some(2.0),
+        )
+        .unwrap();
+        let cpu = measurement.stat;
+        assert_eq!(cpu.total_usage, 85731000);
+        assert_eq!(cpu.user, 53792000);
+        assert_eq!(cpu.system, 117670000);
+    }
+
+    #[test]
+    fn test_read_v2_sys_measurement_half_cpu_count() {
+        let measurement = read_and_parse_v2_sys_stat(
+            &Path::new("fixtures/linux/sys/fs/cgroup_v2/cpu.stat_1"),
+            &Path::new("fixtures/linux/sys/fs/cgroup_v2/cpu.max_garbage"),
+            Some(0.5),
         )
         .unwrap();
         let cpu = measurement.stat;
@@ -128,7 +177,7 @@ mod test {
 
     #[test]
     fn test_read_v2_sys_wrong_path() {
-        match read_and_parse_v2_sys_stat(&Path::new("bananas"), &Path::new("potato")) {
+        match read_and_parse_v2_sys_stat(&Path::new("bananas"), &Path::new("potato"), None) {
             Err(ProbeError::IO(_, _)) => (),
             r => panic!("Unexpected result: {:?}", r),
         }
@@ -139,6 +188,7 @@ mod test {
         match read_and_parse_v2_sys_stat(
             &Path::new("fixtures/linux/sys/fs/cgroup_v2/cpu.stat_incomplete"),
             &Path::new("fixtures/linux/sys/fs/cgroup_v2/cpu.max_default"),
+            None,
         ) {
             Err(ProbeError::UnexpectedContent(_)) => (),
             r => panic!("Unexpected result: {:?}", r),
@@ -149,7 +199,7 @@ mod test {
     fn test_read_and_parse_v2_sys_stat_garbage() {
         let path = Path::new("fixtures/linux/sys/fs/cgroup_v2/cpu.stat_garbage");
         let max_file_path = Path::new("fixtures/linux/fs/cgroup_v2/cpu.max");
-        match read_and_parse_v2_sys_stat(&path, &max_file_path) {
+        match read_and_parse_v2_sys_stat(&path, &max_file_path, None) {
             Err(ProbeError::UnexpectedContent(_)) => (),
             r => panic!("Unexpected result: {:?}", r),
         }
@@ -159,7 +209,7 @@ mod test {
     fn test_read_and_parse_v2_sys_max_garbage() {
         let path = Path::new("fixtures/linux/sys/fs/cgroup_v2/cpu.stat_1");
         let max_file_path = Path::new("fixtures/linux/sys/fs/cgroup_v2/cpu.max_garbage");
-        match read_and_parse_v2_sys_stat(&path, &max_file_path) {
+        match read_and_parse_v2_sys_stat(&path, &max_file_path, None) {
             Err(ProbeError::UnexpectedContent(_)) => (),
             r => panic!("Unexpected result: {:?}", r),
         }
@@ -170,12 +220,14 @@ mod test {
         let mut measurement1 = read_and_parse_v2_sys_stat(
             &Path::new("fixtures/linux/sys/fs/cgroup_v2/cpu.stat_1"),
             &Path::new("fixtures/linux/sys/fs/cgroup_v2/cpu.max_2_cpus"),
+            None,
         )
         .unwrap();
         measurement1.precise_time_ns = 375953965125920;
         let mut measurement2 = read_and_parse_v2_sys_stat(
             &Path::new("fixtures/linux/sys/fs/cgroup_v2/cpu.stat_2"),
             &Path::new("fixtures/linux/sys/fs/cgroup_v2/cpu.max_2_cpus"),
+            None,
         )
         .unwrap();
         measurement2.precise_time_ns = 376013815302920;
@@ -201,12 +253,14 @@ mod test {
         let mut measurement1 = read_and_parse_v2_sys_stat(
             &Path::new("fixtures/linux/sys/fs/cgroup_v2/cpu.stat_1"),
             &Path::new("fixtures/linux/sys/fs/cgroup_v2/cpu.max_half"),
+            None,
         )
         .unwrap();
         measurement1.precise_time_ns = 375953965125920;
         let mut measurement2 = read_and_parse_v2_sys_stat(
             &Path::new("fixtures/linux/sys/fs/cgroup_v2/cpu.stat_2"),
             &Path::new("fixtures/linux/sys/fs/cgroup_v2/cpu.max_half"),
+            None,
         )
         .unwrap();
         measurement2.precise_time_ns = 376013815302920;


### PR DESCRIPTION
Following up from @tombruijn's work on #81.

Add a CPU share parameter that is used instead of the CPU count derived from the cgroups (v1/v2) quota.