### PR TITLE
Use CPU count to weight all measurements

### DIFF
--- a/src/cpu/cgroup.rs
+++ b/src/cpu/cgroup.rs
@@ -58,6 +58,17 @@ impl CgroupCpuStat {
         }
     }
 
+    // Divide the values by the number of (potentially fractional) CPUs allocated to the system.
+    pub fn by_cpu_count(&self, cpu_count: Option<f64>) -> CgroupCpuStat {
+        let cpu_count = cpu_count.filter(|count| *count != 0.0).unwrap_or(1.0);
+
+        CgroupCpuStat {
+            total_usage: (self.total_usage as f64 / cpu_count).round() as u64,
+            user: (self.user as f64 / cpu_count) as u64,
+            system: (self.system as f64 / cpu_count) as u64,
+        }
+    }
+
     fn percentage_of_total(&self, value: u64) -> f32 {
         // 60_000_000_000 being the total value. This is 60 seconds expressed in nanoseconds.
         (value as f32 / 60_000_000_000.0) * 100.0

--- a/src/cpu/cgroup_v1.rs
+++ b/src/cpu/cgroup_v1.rs
@@ -40,11 +40,6 @@ pub fn read_and_parse_v1_sys_stat(
         user: 0,
         system: 0,
     };
-    if let Some(cpu_count) = cpu_count {
-        if cpu_count > 0.0 {
-            cpu.total_usage = (cpu.total_usage as f64 / cpu_count).round() as u64;
-        }
-    }
 
     let mut fields_encountered = 0;
     for line in reader.lines() {
@@ -75,7 +70,7 @@ pub fn read_and_parse_v1_sys_stat(
     }
     let measurement = CgroupCpuMeasurement {
         precise_time_ns: time,
-        stat: cpu,
+        stat: cpu.by_cpu_count(cpu_count),
     };
     Ok(measurement)
 }
@@ -128,8 +123,8 @@ mod test {
         .unwrap();
         let cpu = measurement.stat;
         assert_eq!(cpu.total_usage, 76328606511);
-        assert_eq!(cpu.user, 149340000000);
-        assert_eq!(cpu.system, 980000000);
+        assert_eq!(cpu.user, 74670000000);
+        assert_eq!(cpu.system, 490000000);
     }
 
     #[test]
@@ -143,8 +138,8 @@ mod test {
         .unwrap();
         let cpu = measurement.stat;
         assert_eq!(cpu.total_usage, 305314426042);
-        assert_eq!(cpu.user, 149340000000);
-        assert_eq!(cpu.system, 980000000);
+        assert_eq!(cpu.user, 298680000000);
+        assert_eq!(cpu.system, 1960000000);
     }
 
     #[test]
@@ -189,8 +184,8 @@ mod test {
         .unwrap();
         let cpu = measurement.stat;
         assert_eq!(cpu.total_usage, 305314426042);
-        assert_eq!(cpu.user, 149340000000);
-        assert_eq!(cpu.system, 980000000);
+        assert_eq!(cpu.user, 298680000000);
+        assert_eq!(cpu.system, 1960000000);
     }
 
     #[test]
@@ -204,8 +199,8 @@ mod test {
         .unwrap();
         let cpu = measurement.stat;
         assert_eq!(cpu.total_usage, 76328606511);
-        assert_eq!(cpu.user, 149340000000);
-        assert_eq!(cpu.system, 980000000);
+        assert_eq!(cpu.user, 74670000000);
+        assert_eq!(cpu.system, 490000000);
     }
 
     #[test]
@@ -308,11 +303,11 @@ mod test {
         assert!(in_percentages.total_usage > 24.85);
         assert!(in_percentages.total_usage < 24.86);
 
-        assert!(in_percentages.user > 47.60);
-        assert!(in_percentages.user < 47.61);
+        assert!(in_percentages.user > 23.80);
+        assert!(in_percentages.user < 23.81);
 
-        assert!(in_percentages.system > 0.38);
-        assert!(in_percentages.system < 0.39);
+        assert!(in_percentages.system > 0.19);
+        assert!(in_percentages.system < 0.20);
     }
 
     #[test]
@@ -342,10 +337,10 @@ mod test {
         assert!(in_percentages.total_usage > 99.40);
         assert!(in_percentages.total_usage < 99.41);
 
-        assert!(in_percentages.user > 47.60);
-        assert!(in_percentages.user < 47.61);
+        assert!(in_percentages.user > 95.20);
+        assert!(in_percentages.user < 95.21);
 
-        assert!(in_percentages.system > 0.38);
-        assert!(in_percentages.system < 0.39);
+        assert!(in_percentages.system > 0.76);
+        assert!(in_percentages.system < 0.77);
     }
 }

--- a/src/cpu/cgroup_v2.rs
+++ b/src/cpu/cgroup_v2.rs
@@ -48,12 +48,6 @@ pub fn read_and_parse_v2_sys_stat(
         fields_encountered += match segments[0] {
             "usage_usec" => {
                 cpu.total_usage = value * 1_000;
-
-                if let Some(cpu_count) = cpu_count {
-                    if cpu_count > 0.0 {
-                        cpu.total_usage = (cpu.total_usage as f64 / cpu_count).round() as u64;
-                    }
-                }
                 1
             }
             "user_usec" => {
@@ -79,7 +73,7 @@ pub fn read_and_parse_v2_sys_stat(
     }
     let measurement = CgroupCpuMeasurement {
         precise_time_ns: time,
-        stat: cpu,
+        stat: cpu.by_cpu_count(cpu_count),
     };
     Ok(measurement)
 }
@@ -115,8 +109,8 @@ mod test {
         .unwrap();
         let cpu = measurement.stat;
         assert_eq!(cpu.total_usage, 85731000);
-        assert_eq!(cpu.user, 53792000);
-        assert_eq!(cpu.system, 117670000);
+        assert_eq!(cpu.user, 26896000);
+        assert_eq!(cpu.system, 58835000);
     }
 
     #[test]
@@ -129,8 +123,8 @@ mod test {
         .unwrap();
         let cpu = measurement.stat;
         assert_eq!(cpu.total_usage, 342924000);
-        assert_eq!(cpu.user, 53792000);
-        assert_eq!(cpu.system, 117670000);
+        assert_eq!(cpu.user, 107584000);
+        assert_eq!(cpu.system, 235340000);
     }
 
     #[test]
@@ -157,8 +151,8 @@ mod test {
         .unwrap();
         let cpu = measurement.stat;
         assert_eq!(cpu.total_usage, 85731000);
-        assert_eq!(cpu.user, 53792000);
-        assert_eq!(cpu.system, 117670000);
+        assert_eq!(cpu.user, 26896000);
+        assert_eq!(cpu.system, 58835000);
     }
 
     #[test]
@@ -171,8 +165,8 @@ mod test {
         .unwrap();
         let cpu = measurement.stat;
         assert_eq!(cpu.total_usage, 342924000);
-        assert_eq!(cpu.user, 53792000);
-        assert_eq!(cpu.system, 117670000);
+        assert_eq!(cpu.user, 107584000);
+        assert_eq!(cpu.system, 235340000);
     }
 
     #[test]
@@ -216,7 +210,7 @@ mod test {
     }
 
     #[test]
-    fn test_in_percentages_integration_v2() {
+    fn test_in_percentages_integration_v2_two_cpu() {
         let mut measurement1 = read_and_parse_v2_sys_stat(
             &Path::new("fixtures/linux/sys/fs/cgroup_v2/cpu.stat_1"),
             &Path::new("fixtures/linux/sys/fs/cgroup_v2/cpu.max_2_cpus"),
@@ -240,16 +234,16 @@ mod test {
         assert!(in_percentages.total_usage > 0.08);
         assert!(in_percentages.total_usage < 0.09);
 
-        assert!(in_percentages.user > 0.02);
-        assert!(in_percentages.user < 0.03);
+        assert!(in_percentages.user > 0.01);
+        assert!(in_percentages.user < 0.02);
 
-        assert!(in_percentages.system > 0.13);
-        assert!(in_percentages.system < 0.14);
+        assert!(in_percentages.system > 0.06);
+        assert!(in_percentages.system < 0.07);
     }
 
     // When the cpu.max file does not return an integer.
     #[test]
-    fn test_in_percentages_integration_v2_non_int_max() {
+    fn test_in_percentages_integration_v2_half_cpu() {
         let mut measurement1 = read_and_parse_v2_sys_stat(
             &Path::new("fixtures/linux/sys/fs/cgroup_v2/cpu.stat_1"),
             &Path::new("fixtures/linux/sys/fs/cgroup_v2/cpu.max_half"),
@@ -273,10 +267,10 @@ mod test {
         assert!(in_percentages.total_usage > 0.33);
         assert!(in_percentages.total_usage < 0.34);
 
-        assert!(in_percentages.user > 0.02);
-        assert!(in_percentages.user < 0.03);
+        assert!(in_percentages.user > 0.05);
+        assert!(in_percentages.user < 0.06);
 
-        assert!(in_percentages.system > 0.13);
-        assert!(in_percentages.system < 0.14);
+        assert!(in_percentages.system > 0.27);
+        assert!(in_percentages.system < 0.28);
     }
 }


### PR DESCRIPTION
Before this change, only the `total_usage` metric was weighted by the number of CPUs.

Weight `user` and `system` by the number of CPUs as well.

See [Intercom thread](https://app.intercom.com/a/inbox/yzor8gyw/inbox/shared/all/conversation/16410700277823#part_id=comment-16410700277823-21909556019) for context.